### PR TITLE
CRAYSAT-1593: Fix set_timeout() type signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2022-10-10
+
+### Changed
+- Changed the type signature of `APIGatewayClient.set_timeout()` to allow
+  `None` as an argument to permit disabling request timeouts.
+
 ## [1.0.0] - 2022-08-26
 
 ### Added

--- a/csm_api_client/service/gateway.py
+++ b/csm_api_client/service/gateway.py
@@ -92,7 +92,7 @@ class APIGatewayClient:
         self.session = session
         self.timeout = timeout
 
-    def set_timeout(self, timeout: int) -> None:
+    def set_timeout(self, timeout: Optional[int]) -> None:
         self.timeout = timeout
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "1.0.0"
+version = "1.1.0"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",


### PR DESCRIPTION
## Summary and Scope

This change fixes the type signature of the set_timeout() method so that it permits `None` to be passed. This allows `None` to be used for the `timeout` parameter for `requests.request()`, which does not time out requests after a time limit.

## Issues and Related PRs

* Resolves [CRAYSAT-1593](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1593)

## Testing

### Tested on:

  * Local development environment

### Test description:

Run type checker on SAT codebase after updating `csm-api-client` builds.

## Risks and Mitigations
None - no functionality changing

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

