### PR TITLE
CRAYSAT-1620: Use authentication when accessing csm-python-modules

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -45,6 +45,9 @@ pipeline {
     stages {
         stage('Build Prep') {
             steps {
+                script {
+                    jenkinsUtils.writeNetRc()
+                }
                 sh './build_scripts/build.sh prep'
             }
         }


### PR DESCRIPTION
This commit adds creation of a .netrc file on the Jenkins host on which the build is running. The intention of this file is to provide credential authentication in the case when the package's dependencies are being installed in a VirtualEnv on the host to facilitate running unit tests. This uses the utility jenkinsUtils.writeNetRc() found in csm-shared-library.

Test Description: Built package in Jenkins
