### PR TITLE
CRAYSAT-1650: Fix patch method of APIGatewayClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-(C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.1] - 2023-01-11
+
+### Fixed
+- Fixed the `APIGateayClient._make_req` method to pass the `json` keyword
+  argument through when making a PATCH request with the `patch` method.
 
 ## [1.1.0] - 2022-10-10
 

--- a/csm_api_client/service/gateway.py
+++ b/csm_api_client/service/gateway.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -166,7 +166,7 @@ class APIGatewayClient:
             elif req_type == 'PUT':
                 r = requester.put(url, data=req_param, json=json, timeout=self.timeout)
             elif req_type == 'PATCH':
-                r = requester.patch(url, data=req_param, timeout=self.timeout)
+                r = requester.patch(url, data=req_param, json=json, timeout=self.timeout)
             elif req_type == 'DELETE':
                 r = requester.delete(url, timeout=self.timeout)
             else:

--- a/tests/service/test_gateway.py
+++ b/tests/service/test_gateway.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -127,6 +127,39 @@ class TestAPIGatewayClient(unittest.TestCase):
         payload = {}
         with self.assertRaises(APIError):
             client.put(*path_components, payload=payload)
+
+    def test_patch(self):
+        """Test patch method."""
+        client = APIGatewayClient(self.mock_session, timeout=60)
+        path_components = ['foo', 'bar', 'baz']
+        payload = {}
+        client.patch(*path_components, payload=payload)
+
+        self.mock_session.session.patch.assert_called_once_with(
+            get_http_url_prefix(self.api_gw_host) + '/'.join(path_components),
+            data=payload, json=None, timeout=60
+        )
+
+    def test_patch_json(self):
+        """Test patch method with json payload."""
+        client = APIGatewayClient(self.mock_session, timeout=60)
+        path_components = ['foo', 'bar', 'baz']
+        json_payload = {'field': 'value'}
+        client.patch(*path_components, json=json_payload)
+
+        self.mock_session.session.patch.assert_called_once_with(
+            get_http_url_prefix(self.api_gw_host) + '/'.join(path_components),
+            data=None, json=json_payload, timeout=60
+        )
+
+    def test_patch_exception(self):
+        """Test patch method with exception during PATCH."""
+        self.mock_session.session.patch.side_effect = requests.exceptions.RequestException
+        client = APIGatewayClient(self.mock_session)
+        path_components = ['foo', 'bar', 'baz']
+        payload = {}
+        with self.assertRaises(APIError):
+            client.patch(*path_components, payload=payload)
 
     def test_delete(self):
         """Test delete method."""


### PR DESCRIPTION
## Summary and Scope

The `_make_req` method was dropping the `json` kwarg when making the request, which caused calls to the `patch` method that used the `json` keyword argument to fail.

## Issues and Related PRs

* Resolves [CRAYSAT-1650](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1650)

## Testing


### Tested on:

  * frigg

### Test description:

Unit tests pass. Manually made this change in a `sat bash` container image and verified that the image renaming step in `sat bootprep` was working again.

## Risks and Mitigations

Low risk.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable