### PR TITLE
CRAYSAT-1650: Fix version in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "1.1.0"
+version = "1.1.1"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",


### PR DESCRIPTION
## Summary and Scope

This version is actually what controls the version of the package published to artifactory.

## Testing

### Tested on:
  * Local development environment

### Test description:
Ran `./build_scripts/build.sh python_package` to make sure the 1.1.1 version was built.
