### PR TITLE
CRAYSAT-1678: Fix token fetch during authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2023-02-10
+
+### Fixed
+- Fixed the `UserSession.token` property to handle token fetching and existing
+  tokens correctly.
+
 ## [1.1.1] - 2023-01-11
 
 ### Fixed
-- Fixed the `APIGateayClient._make_req` method to pass the `json` keyword
+- Fixed the `APIGatewayClient._make_req` method to pass the `json` keyword
   argument through when making a PATCH request with the `patch` method.
 
 ## [1.1.0] - 2022-10-10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "1.1.1"
+version = "1.1.2"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",


### PR DESCRIPTION
## Summary and Scope

This change fixes the way tokens are handled when a new token is being fetched. Previously when a token file didn't already exist for a token, a new token would be fetched but not saved, and subsequent API calls could not use the token.

## Issues and Related PRs

* Resolves [CRAYSAT-1678](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1678)

## Testing

### Tested on:

  * `frigg`
  * Local development environment

### Test description:

Run unit tests. Test `sat auth` with empty config directory to ensure that new tokens can be created.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

