### PR TITLE
CRAYSAT-1673: Update CFS container ordering logic

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -41,7 +41,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v34
+      uses: tj-actions/changed-files@v35
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2023-04-10
+
+### Fixed
+- Fixed a bug where the incorrect pod was being recommended for debug log
+  viewing when an image customization job failed.
+
 ## [1.1.2] - 2023-02-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "1.1.2"
+version = "1.1.3"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",


### PR DESCRIPTION
## Summary and Scope
The name scheme for CFS image customization containers has been changed such that Ansible containers no longer have a numeric suffix. As a result, the 'teardown' container was being recommended as the suggested container from which to view logs. This is incorrect for customization jobs where the 'ansible' container fails.

## Issues and Related PRs

* Resolves [CRAYSAT-1673](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1673)/[CASMTRIAGE-4983](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4983)

## Testing

### Tested on:

  * `gamora`

### Test description:

Run unit tests. Run test with mock bootprep file with barebones image and failing CFS configuration; confirm that the correct ansible container is selected as the debug container.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

