### PR TITLE
CASMINST-6597: Add additional CFS client functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2023-08-14
+
+### Added
+- Added the ability to back up existing CFS configurations or files when saving
+  `CFSConfiguration` objects with `save_to_cfs` or `save_to_file` methods by
+  adding a `backup_suffix` argument.
+- Added a `get_component_ids_using_config` method to `CFSClient` that returns
+  the IDs of all components using a given configuration as their desiredConfig.
+- Added an `update_component` method to `CFSClient` that updates a given
+  component in CFS.
+
 ## [1.1.5] - 2023-07-31
 
 ### Changed

--- a/csm_api_client/service/cfs.py
+++ b/csm_api_client/service/cfs.py
@@ -31,11 +31,13 @@ from itertools import chain
 import json
 import logging
 import re
+import shutil
 from typing import (
     Dict,
     Iterable,
     List,
     Optional,
+    Union
 )
 from urllib.parse import urlparse, urlunparse
 import uuid
@@ -384,7 +386,7 @@ class CFSConfiguration:
         return {'layers': [layer.req_payload for layer in self.layers]}
 
     def save_to_cfs(self, name: Optional[str] = None,
-                    overwrite: bool = True) -> 'CFSConfiguration':
+                    overwrite: bool = True, backup_suffix: Union[str, None] = None) -> 'CFSConfiguration':
         """Save the configuration to CFS, optionally with a new name.
 
         Args:
@@ -394,6 +396,9 @@ class CFSConfiguration:
                 configuration given by `name`. If False, raise a
                 CFSConfigurationError if a configuration with `name` already
                 exists
+            backup_suffix: if specified, before saving the current version of
+                the CFS configuration, if it already exists in CFS, save a
+                backup with the given suffix.
 
         Returns:
             the new configuration that was saved to CFS
@@ -409,23 +414,42 @@ class CFSConfiguration:
         else:
             raise ValueError('A name must be specified for the CFS configuration.')
 
-        # If overwriting is disabled, throw an error if we try to overwrite a
-        # configuration
-        if not overwrite:
+        existing_cfs_config_data = None
+        # Check if a CFS configuration with the given name already exists when
+        # overwrite is disallowed or when a backup is requested.
+        if not overwrite or backup_suffix:
             try:
                 response = self._cfs_client.get('configurations', cfs_name, raise_not_ok=False)
 
                 # If response was OK, that indicates there's already a CFS configuration
                 if response.ok:
-                    raise CFSConfigurationError(f'A configuration named {cfs_name} already exists '
-                                                f'and will not be overwritten.')
+                    try:
+                        existing_cfs_config_data = response.json()
+                    except ValueError as err:
+                        raise CFSConfigurationError(f'Failed to decode JSON response from reading'
+                                                    f'existing CFS configuration "{cfs_name}": {err}')
+
                 elif response.status_code != 404:
                     # If there's a failure for any reason other than a missing
-                    # configuration, throw an APIError
+                    # configuration, throw the APIError and catch it below
                     self._cfs_client.raise_from_response(response)
 
             except APIError as err:
-                raise CFSConfigurationError(f'Failed to retrieve CFS configuration "{cfs_name}": {err}')
+                raise CFSConfigurationError(f'Failed to check for existing CFS '
+                                            f'configuration "{cfs_name}": {err}') from err
+
+        if existing_cfs_config_data:
+            if not overwrite:
+                raise CFSConfigurationError(f'A configuration named {cfs_name} already exists '
+                                            f'and will not be overwritten.')
+            if backup_suffix:
+                backup_config_name = f'{cfs_name}{backup_suffix}'
+                try:
+                    backup_config = CFSConfiguration(self._cfs_client, existing_cfs_config_data)
+                    backup_config.save_to_cfs(name=backup_config_name)
+                except CFSConfigurationError as err:
+                    raise CFSConfigurationError(f'Failed to back up CFS configuration "{cfs_name}" '
+                                                f'to "{backup_config_name}": {err}') from err
 
         try:
             response_json = self._cfs_client.put('configurations', cfs_name,
@@ -439,14 +463,18 @@ class CFSConfiguration:
         LOGGER.info('Successfully saved CFS configuration "%s"', cfs_name)
         return CFSConfiguration(self._cfs_client, response_json)
 
-    def save_to_file(self, file_path: str, overwrite: bool = True) -> None:
+    def save_to_file(self, file_path: str, overwrite: bool = True,
+                     backup_suffix: Union[str, None] = None) -> None:
         """Save the configuration to a file.
 
         Args:
             file_path: the path to the file where this config should be saved
             overwrite: if True, silently overwrite an existing file
-            given by `file_path`. If False, raise a CFSConfigurationError if
-            `file_path` already exists.
+                given by `file_path`. If False, raise a CFSConfigurationError if
+                `file_path` already exists.
+            backup_suffix: if specified, before saving the current version of
+                the CFS configuration to a file, if the file already exists,
+                save a backup file with the given suffix.
 
         Returns:
             None
@@ -455,6 +483,18 @@ class CFSConfiguration:
             CFSConfigurationError: if there is a failure saving the configuration
                 to the file, or if the file exists and overwrite is `False`.
         """
+        # It only makes sense to make a backup copy if overwriting is requested
+        if backup_suffix and overwrite:
+            path_without_ext, ext = os.path.splitext(file_path)
+            backup_file_path = f'{path_without_ext}{backup_suffix}{ext}'
+            try:
+                shutil.copyfile(file_path, backup_file_path)
+            except FileNotFoundError:
+                LOGGER.debug(f'File {file_path} does not exist so does not need to be backed up.')
+            except OSError as err:
+                raise CFSConfigurationError(f'Failed to copy {file_path} to {backup_file_path} '
+                                            f'before overwriting: {err}') from err
+
         try:
             with open(file_path, 'w' if overwrite else 'x') as f:
                 json.dump(self.req_payload, f, indent=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "1.1.5"
+version = "1.2.0"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",


### PR DESCRIPTION
* CASMINST-6597: Declare version 1.2.0 of csm-api-client

  Update the changelog and declare a new version in `pyproject.toml`.

* CASMINST-6597: Add methods to CFSClient to support cfs-config-util

  Add a couple methods to the `CFSClient` class to support functionality
  needed by `cfs-config-util`.

  Add a method `get_component_ids_using_config` that gets a list of the
  CFS component IDs for all components that have the given CFS
  configuration assigned as their `desiredConfig`.

  Add a method `update_component` that updates a CFS component based on
  the given parameters.

  Test Description:
  New unit tests are passing.

  Tested manually on my macbook in a Python virtual environment with the
  `sat` package and this version of `csm_api_client` installed. Created a
  `CFSClient` with `CFSClient(SATSession())` and then got a
  `CFSConfiguration` object and called `get_component_ids_using_config`
  with a few different configuration values and called `update_component`
  with just `clear_error=True` to make sure it worked.

  Tested by building a `cfs-config-util` that uses this new version of the
  library from this branch and executed it on mug. Tested that it
  correctly identified components which had their CFS configuration
  updated and could also update component fields with various options.

* CASMINST-6597: Add option to back up when saving CFSConfiguration

  Add the ability to back up existing files or CFS configurations when saving
  `CFSConfiguration` objects with `save_to_cfs` or `save_to_file` methods.
  This is supported through a new `backup_suffix` string argument which
  specifies the suffix to use when backup up the CFS configuration or the
  file containing the CFS configuration payload. If the `backup_suffix` is
  not specified, then it defaults to not backing up, which preserves
  existing behavior.

  Test Description:
  New unit tests are passing.

  Tested manually on my macbook in a Python virtual environment with the
  `sat` package and this version of `csm_api_client` installed. Created a
  `CFSClient` with `CFSClient(SATSession())` and then got a
  `CFSConfiguration` object and tried various calls to `save_to_cfs` and
  `save_to_file` methods.

  Tested ability to create backups with `cfs-config-util` with new
  `--create-backups` option on mug.

## Issues and Related PRs

* Part of [CASMINST-6597](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6597)
* Merge before associated cfs-config-util PR TBD

## Testing

See test descriptions in commit messages as above.

# Risks and Mitigations

This is pretty low-risk as it's just added new methods and parameters used by `cfs-config-util`.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable