### PR TITLE
CRAYSAT-1747:Allow passing CFS session name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2024-03-26
+
+### Changed
+- updated `create_image_customization_session` to allow passing of session name 
+  in order to maintain consistency with logging
+
 ## [1.2.0] - 2023-08-14
 
 ### Added

--- a/csm_api_client/service/cfs.py
+++ b/csm_api_client/service/cfs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -1001,7 +1001,7 @@ k
                            f'CFS session {name}: {err}')
 
     def create_image_customization_session(
-        self, config_name: str, image_id: str,
+        self, session_name: str, config_name: str, image_id: str,
         target_groups: Iterable[str], image_name: str
     ) -> CFSImageConfigurationSession:
         """Create a new image customization session.
@@ -1009,6 +1009,7 @@ k
         The session name will be generated with self.get_valid_session_name.
 
         Args:
+            session_name: the name of the session
             config_name: the name of the configuration to use
             image_id: the id of the IMS image to customize
             target_groups: the group names to target. Each group
@@ -1021,7 +1022,7 @@ k
             The created session
         """
         request_body = {
-            'name': self.get_valid_session_name(),
+            'name': session_name,
             'configurationName': config_name,
             'target': {
                 'definition': 'image',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "1.2.0"
+version = "1.2.1"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",


### PR DESCRIPTION
IM:CRAYSAT-1747
Reviewer: Ryan

## Summary and Scope

Incorrect logging is observed in sat bootprep logs SAT is also generating a session name, which is conflicting with session name generated in create_image_customization_session

Hence 2 session names are observed in log, leading to confusion

Allowing to pass a CFS session name from sat to cfs.py as this would allow in maintaining consistency with logging.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1747](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1747)


## Testing

baldar

### Tested on:

Tested on baldar

### Test description:

validated the sat bootprep with single layer yaml file to verify if the same session name is reflected in the logging

## Risks and Mitigations

Minimal

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

