### PR TITLE
CRAYSAT-1775:Update container status when it is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-(C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.2] - 2024-03-26
+
+### Fixed
+- Update the `_update_container_status` method of the 
+  CFSImageConfigurationSession class to handle the case when either
+  `init_container_statuses` or `container_statuses` or both are None.
 
 ## [1.2.1] - 2024-03-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "1.2.1"
+version = "1.2.2"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",


### PR DESCRIPTION
IM:CRAYSAT-1775
Reviewer:Ryan

## Summary and Scope

Update the _update_container_status method when either init_container_statuses or container_statuses or both are None._
_If they are None we can log an info message and will skip processing the container statuses until they are populated._

## Issues and Related PRs

_Resolves [CRAYSAT-1775](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1775)_

## Testing

_List the environments in which these changes were tested._

### Tested on:

 TO DO

### Test description:

TO DO

## Risks and Mitigations

_Minimal_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

