### PR TITLE
CRAYSAT-1775: Improve upon `_update_container_status` tests

### DIFF
--- a/csm_api_client/service/cfs.py
+++ b/csm_api_client/service/cfs.py
@@ -821,7 +821,7 @@ class CFSImageConfigurationSession:
                 for container_status in chain(
                     self.pod.status.init_container_statuses,
                     self.pod.status.container_statuses,
-                )
+                ) if container_status is not None
             )
         status_width = max(len(status) for status in [
                 self.CONTAINER_RUNNING_VALUE,
@@ -862,7 +862,7 @@ class CFSImageConfigurationSession:
             status_by_name = getattr(self, f'{prefix}container_status_by_name')
             container_statuses = getattr(self.pod.status, f'{prefix}container_statuses')
             if container_statuses is None:
-                state_log_msgs.append(f'Waiting for container statuses in pod: {prefix}container_statuses is None. ')
+                state_log_msgs.append(f'Waiting for container statuses in pod: {prefix}container_statuses is None.')
                 break
 
             for container_status in container_statuses:

--- a/tests/service/test_cfs.py
+++ b/tests/service/test_cfs.py
@@ -749,7 +749,6 @@ class TestCFSDebugCommand(unittest.TestCase):
 
     def setUp(self):
         self.failed_container = CFSImageConfigurationSession.get_first_failed_container
-        self.update_status = CFSImageConfigurationSession._update_container_status
 
     def test_get_failing_init_container(self):
         """Check that init containers are always selected first"""
@@ -774,29 +773,106 @@ class TestCFSDebugCommand(unittest.TestCase):
         """Check that no debug message is given if there are no failing containers"""
         self.assertIsNone(self.failed_container([], []))
 
+
+class TestCFSUpdateContainerStatus(unittest.TestCase):
+    """Tests for the _update_container_status method of CFSImageConfigurationSession"""
+
+    def setUp(self):
+        """Create a CFSImageConfigurationSession to use in the tests"""
+        self.session_name = 'test_session'
+        self.image_name = 'test_image'
+        self.session = CFSImageConfigurationSession({'name': self.session_name},
+                                                    MagicMock(spec=CFSClient),
+                                                    self.image_name)
+
+        # Mock out a single init_container_status element
+        self.init_container_status = MagicMock()
+        self.init_container_status.name = 'git-clone'
+        self.init_container_status.state.running = None
+        self.init_container_status.state.terminated = MagicMock()
+        self.init_container_status.state.terminated.exit_code = 0
+        self.init_container_statuses = [self.init_container_status]
+
+        # Mock out two container_status elements
+        self.inventory_container_status = MagicMock()
+        self.inventory_container_status.name = 'inventory'
+        self.inventory_container_status.state.running = True
+        self.ansible_container_status = MagicMock()
+        self.ansible_container_status.name = 'ansible'
+        self.ansible_container_status.state.running = True
+        self.container_statuses = [self.inventory_container_status, self.ansible_container_status]
+
+        self.session.pod = MagicMock()
+        self.session.pod.status.init_container_statuses = self.init_container_statuses
+        self.session.pod.status.container_statuses = self.container_statuses
+
+    def test_update_container_status(self):
+        """Test _update_container_status when containers are successfully found"""
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            self.assertIsNone(self.session._update_container_status())
+
+        # One message is logged describing the session, and one for each container reporting status
+        # for the first time
+        self.assertEqual(4, len(logs_cm.records))
+        self.assertRegexpMatches(logs_cm.records[0].message,
+                                 f'CFS session: {self.session_name} *Image: {self.image_name}')
+        self.assertRegexpMatches(logs_cm.records[1].message,
+                                 'Container git-clone *transitioned to succeeded')
+        self.assertRegexpMatches(logs_cm.records[2].message,
+                                 'Container inventory *transitioned to running')
+        self.assertRegexpMatches(logs_cm.records[3].message,
+                                 'Container ansible *transitioned to running')
+
+        # Now simulate completion of the inventory and ansible container
+        self.inventory_container_status.state.running = None
+        self.inventory_container_status.state.terminated = MagicMock()
+        self.inventory_container_status.state.terminated.exit_code = 0
+        self.ansible_container_status.state.running = None
+        self.ansible_container_status.state.terminated = MagicMock()
+        self.ansible_container_status.state.terminated.exit_code = 0
+        # Update container status again
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            self.assertIsNone(self.session._update_container_status())
+
+        # One message is logged describing the session, and one for each container reporting new status
+        self.assertEqual(3, len(logs_cm.records))
+        self.assertRegexpMatches(logs_cm.records[0].message,
+                                 f'CFS session: {self.session_name} *Image: {self.image_name}')
+        self.assertRegexpMatches(logs_cm.records[1].message,
+                                 'Container inventory *transitioned to succeeded from running')
+        self.assertRegexpMatches(logs_cm.records[2].message,
+                                 'Container ansible *transitioned to succeeded from running')
+
     def test_update_container_status_with_none_pod(self):
         """Check that update_container_status returns None when pod is None"""
-        session = CFSImageConfigurationSession({}, MagicMock(), 'test_image')
-        session.pod = None
-        self.assertIsNone(self.update_status(session))
+        self.session.pod = None
+        self.assertIsNone(self.session._update_container_status())
 
     def test_update_container_status_with_none_init_and_container_statuses(self):
         """Check that update_container_status returns None when both init and container statuses are None"""
-        session = CFSImageConfigurationSession({}, MagicMock(), 'test_image')
-        session.pod = MagicMock()
-        session.pod.status.init_container_statuses = None
-        session.pod.status.container_statuses = None
-        self.assertIsNone(self.update_status(session))
+        self.session.pod.status.init_container_statuses = None
+        self.session.pod.status.container_statuses = None
+
+        with self.assertLogs(level=logging.INFO) as logs_cm:
+            self.assertIsNone(self.session._update_container_status())
+
+        self.assertEqual(2, len(logs_cm.records))
+        self.assertRegexpMatches(logs_cm.records[0].message,
+                                 f'CFS session: {self.session_name} *Image: {self.image_name}')
+        self.assertRegexpMatches(logs_cm.records[1].message,
+                                 'Waiting for container statuses in pod: init_container_statuses is None')
 
     def test_update_container_status_with_none_init_statuses(self):
-        """Check that update_container_status logs a message when init_container_statuses is None"""
-        session = CFSImageConfigurationSession({}, MagicMock(), 'test_image')
-        session.pod = MagicMock()
-        session.pod.status.init_container_statuses = [None,MagicMock()]
-        session.pod.status.container_statuses = [MagicMock()]
-        with self.assertLogs() as log:
-            self.update_status(session)
-        self.assertIn('Found a None container', log.output[0])
+        """Check that update_container_status logs a message one of init_container_statuses is None"""
+        self.session.pod.status.init_container_statuses = [None, self.init_container_status]
+
+        with self.assertLogs(level=logging.DEBUG) as logs_cm:
+            self.assertIsNone(self.session._update_container_status())
+
+        for log_record in logs_cm.records:
+            if log_record.levelno == logging.DEBUG:
+                self.assertIn('Found a None container in init_container_status',
+                              logs_cm.records[0].message)
 
 
 class TestCFSClient(unittest.TestCase):


### PR DESCRIPTION
## Summary and Scope
Improve upon unit test for `_update_container_status` method as follows:

* Separate tests into their own class since they are different enough from other existing TestCase class.
* Add more thoroughly mocked out container status data in the `setUp` method.
* Add a unit test that tests the "happy path" through the method and asserts against the info-level log messages.
* Add more assertions on the log messages logged in the various scenarios when the `init_container_statuses` and/or `container_statuses` are `None`.

## Issues and Related PRs

* Part of CRAYSAT-1775

## Testing

### Tested on:

  * Local development environment

### Test description:
Unit tests pass.

## Risks and Mitigations

Low risk unit test improvements.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable