### PR TITLE
CRAYSAT-1848: Fix kubernetes version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2024-04-25
+
+### Fixed
+- Relax the constraint on the version of the `kubernetes` package to allow this
+  library to be used by different versions of sat that require different
+  versions of Kubernetes matching the versions included in CSM.
+
 ## [1.2.3] - 2024-04-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "1.2.3"
+version = "1.2.4"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",
@@ -17,7 +17,7 @@ packages = [{include = "csm_api_client"}]
 python = "^3.8"
 boto3 = "^1.21.0"
 inflect = ">=0.2.5"
-kubernetes = "^23.0.0"
+kubernetes = ">=22.0.0"
 PyYAML = "<7.0"
 requests = "<3.0"
 requests-oauthlib = "^1.3.1"


### PR DESCRIPTION
## Summary and Scope

The kubernetes package version constraint was requiring too new of a version of kuberenetes. When this library is used by a version of sat for CSM 1.5, we want to use a 22.y.z version of the kubernetes package to match the 1.22 version of the Kubernetes cluster. When used by a version of sat for CSM 1.6, we want to use a 23.y.z version of the kubernetes package to match the 1.23 version of the Kubernetes cluster.

Relax the constraint to just require version 22 or newer. The lock file can stay the same as it's not used when this package is included as a dependency.

## Issues and Related PRs

* Resolves CRAYSAT-1848
* The sat repo will be updated to use this new version

## Testing

### Tested on:

  * odin

### Test description:

Built a new cray-sat container image using this unstable version. In a Python interpreter in the cray-sat container, tested as follows:

```
ncn-m001:~/haasken # echo $SAT_IMAGE
artifactory.algol60.net/sat-docker/unstable/cray-sat:3.28.1-20240425163740_6f7a544
ncn-m001:~/haasken # sat bash
(20697d8313c1) sat-container:/sat/share # pip show kubernetes
Name: kubernetes
Version: 22.6.0
Summary: Kubernetes python client
Home-page: https://github.com/kubernetes-client/python
Author: Kubernetes
Author-email:
License: Apache License Version 2.0
Location: /sat/venv/lib/python3.9/site-packages
Requires: certifi, google-auth, python-dateutil, pyyaml, requests, requests-oauthlib, setuptools, six, urllib3, websocket-client
Required-by: cray-product-catalog, csm-api-client, sat
(20697d8313c1) sat-container:/sat/share # python
Python 3.9.18 (main, Aug 26 2023, 11:50:23)
[GCC 10.3.1 20211027] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from csm_api_client.k8s import load_kube_api
>>> k = load_kube_api()
>>> n = k.list_node()
>>> len(n.items)
9
```

## Risks and Mitigations

Should be pretty low risk. This just relaxes the constraint imposed on the Kubernetes version in this library.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
