### PR TITLE
CRAYSAT-1392: Graceful handle of traceback error during sat authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] -  2024-08-12
+
+### Added
+- Added exception to handle InvalidGrant Error. This would address the traceback errors shown during sat authentication while executing other sat commands as well. 
 ## [2.0.0] - 2024-08-08
 
 ### Added

--- a/csm_api_client/service/gateway.py
+++ b/csm_api_client/service/gateway.py
@@ -25,6 +25,7 @@
 Client for querying the API gateway.
 """
 from functools import wraps
+from oauthlib.oauth2 import InvalidGrantError
 import logging
 import requests
 from typing import (
@@ -177,6 +178,11 @@ class APIGatewayClient:
             else:
                 # Internal error not expected to occur.
                 raise ValueError("Request type '{}' is invalid.".format(req_type))
+        # Handle invalid_grant error specifically
+        except InvalidGrantError as err:
+            raise APIError(
+                "Invalid grant error: The token is not active or is invalid. "
+                "Please re-authenticate using 'sat auth' to obtain a new token") from err
         except requests.exceptions.ReadTimeout as err:
             if req_type == 'STREAM':
                 raise ReadTimeout("{} request to URL '{}' timeout: {}".format(req_type, url, err))


### PR DESCRIPTION
## Summary and Scope

Added an exception to handle InvalidGrant Error. This would address the traceback errors shown during sat authentication while executing the sat commands.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1392](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1392)
* Change will also be needed in `sat` repo

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Rocket
  

### Test description:

Manually the expiry date was updated in ~/.config/sat/tokens/api_gw_service_nmn_local.vers.json to replicate the issue.
And then the sat commands such as sat status, hwinv, hwmatch were executed to validate the changes


## Risks and Mitigations

Minimal risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

