### PR TITLE
CRAYSAT-1840: Add support for CFS v3 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2024-09-04
+
+### Added
+- Added support for CFS v3 while retaining support for CFS v2. The existing
+  unversioned classes `CFSClient`, `CFSConfiguration`, and
+  `CFSConfigurationLayer` are now aliases for the `CFSV2Client`,
+  `CFSV2Configuration`, and `CFSV2ConfigurationLayer` classes. New classes
+  prefixed with `CFSV3` are added for CFS V3.
+- Added support for creating CFS configurations with the `additional_inventory`
+  property.
+- Added support for creating CFS configuration layers with the
+  `ims_require_dkms` special parameter.
+
+### Fixed
+- When loading a CFS configuration into the appropriate `CFSV2Configuration` or
+  `CFSV3Configuration` class, all properties known to CFS should now be retained
+  when it is modified and saved back into CFS via the CFS API. Formerly, the
+  `additional_inventory` of a CFS configuration and the `ims_require_dkms`
+  property would have been dropped by this library.
+
 ## [2.1.2] - 2024-09-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2024-09-04
+
+### Fixed
+- Fixed how `put`, `patch`, and `post` methods of `APIGatewayClient` class pass
+  their request bodies and request parameters, so that they can use both. To
+  call one of these methods with request parameters, use the `req_param` keyword
+  argument.
+
 ## [2.1.1] - 2024-09-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.1.0] - 2024-08-09
 
 ### Fixed
-- Updating the `cray-product-catalog` to latest version that handles the split Kubernetes ConfigMap.
+- Updating the `cray-product-catalog` to latest version that handles the split
+  Kubernetes ConfigMap.
 
 ## [2.0.0] - 2024-08-08
 

--- a/csm_api_client/service/cfs.py
+++ b/csm_api_client/service/cfs.py
@@ -24,7 +24,9 @@
 """
 Basic client library for CFS.
 """
+from abc import ABC, abstractmethod
 import os.path
+from copy import deepcopy
 from datetime import datetime, timedelta
 from enum import Enum
 from functools import cached_property
@@ -34,10 +36,13 @@ import logging
 import re
 import shutil
 from typing import (
+    Any,
     Dict,
+    Generator,
     Iterable,
     List,
     Optional,
+    Type,
     Union
 )
 from urllib.parse import urlparse, urlunparse
@@ -56,7 +61,7 @@ from semver import VersionInfo
 from csm_api_client.service.gateway import APIError, APIGatewayClient
 from csm_api_client.service.hsm import HSMClient
 from csm_api_client.service.vcs import VCSError, VCSRepo
-from csm_api_client.util import get_val_by_path
+from csm_api_client.util import get_val_by_path, pop_val_by_path, set_val_by_path, strip_suffix
 
 LOGGER = logging.getLogger(__name__)
 MAX_BRANCH_NAME_WIDTH = 7
@@ -81,69 +86,125 @@ class CFSConfigurationError(Exception):
     """Represents an error that occurred while modifying CFS."""
 
 
-class CFSConfigurationLayer:
-    """A layer in a CFS configuration."""
+class CFSLayerBase(ABC):
+    """A common base for layers in a CFS configuration.
 
-    # A mapping from the properties in CFS response data to attributes of this class
-    CFS_PROPS_TO_ATTRS = {
-        'cloneUrl': 'clone_url',
+    This is an abstract base class not specific to any version of CFS. It must
+    be subclassed to support either CFS v2 or CFS v3. It includes common
+    functionality for both versions of CFS.
+
+    This class is the parent class for both the layers and the additional
+    inventory that can be included in a CFS configuration.
+    """
+
+    # Default mapping from CFS properties to attributes of this class
+    CFS_PROPS_TO_ATTRS: Dict[str, str] = {
         'commit': 'commit',
         'branch': 'branch',
         'name': 'name',
-        'playbook': 'playbook'
     }
-    ATTRS_TO_CFS_PROPS = {val: key for key, val in CFS_PROPS_TO_ATTRS.items()}
+    # This gets automatically overwritten in the __init_subclass__ method. It is
+    # the reverse mapping from attributes of the class to CFS properties.
+    ATTRS_TO_CFS_PROPS: Dict[str, str] = {value: key for key, value in CFS_PROPS_TO_ATTRS.items()}
+    # These are the attributes that must match for a layer to be considered the same
+    # as another layer (apart from the version). Subclasses can add to or override this.
+    MATCHING_ATTRS = ['repo_path']
 
-    def __init__(self, clone_url: str,
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Sets up class attribute mapping from attributes to CFS properties"""
+        super().__init_subclass__(**kwargs)
+        # Create the reverse mapping from attributes to CFS properties automatically
+        cls.ATTRS_TO_CFS_PROPS = {val: key for key, val in cls.CFS_PROPS_TO_ATTRS.items()}
+
+    def __init__(self,
+                 clone_url: Optional[str] = None,
                  name: Optional[str] = None,
-                 playbook: Optional[str] = None,
                  commit: Optional[str] = None,
-                 branch: Optional[str] = None) -> None:
-        """Create a new CFSConfiguration.
+                 branch: Optional[str] = None,
+                 additional_data: Optional[dict] = None) -> None:
+        """Create a new layer.
 
         Args:
             clone_url: the git repository clone URL
-            name (str, optional): the name of the CFS configuration layer. The
+            name: the name of the CFS configuration layer. The
                 name is optional.
-            playbook: the name of the Ansible playbook. If
-                omitted, the CFS-internal default is used.
             commit: the commit hash to use. Either `commit` or
                 `branch` is required.
             branch: the git branch to use. Either `commit` or
                 `branch` is required.
+            additional_data: any extra data included in a layer that is not
+                explicitly understood by this class.
 
         Raises:
             ValueError: if neither `commit` nor `branch` is specified.
         """
         self.clone_url = clone_url
-        self.name = name
-        self.playbook = playbook
+        self._name = name
         if not (commit or branch):
             raise ValueError('Either commit or branch is required to create '
-                             'a CFSConfigurationLayer.')
+                             'a CFS configuration layer.')
         self.commit = commit
         self.branch = branch
+        self.additional_data = additional_data or {}
+
+    @property
+    def name(self) -> str:
+        """the name of the CFS configuration layer"""
+        if self._name is not None:
+            return self._name
+
+        branch_or_commit = self.branch or self.commit
+        # This shouldn't happen given that __init__ checks that one is specified,
+        # but program defensively and satisfy mypy type-checking.
+        if not branch_or_commit:
+            branch_or_commit = 'default'
+
+        name_components = [
+            self.repo_short_name,
+            branch_or_commit[:MAX_BRANCH_NAME_WIDTH],
+            datetime.now().strftime('%Y%m%dT%H%M%S')
+        ]
+        return '-'.join(name_components)
 
     @property
     def repo_path(self) -> str:
         """the path portion of the clone URL, e.g. /vcs/cray/sat-config-management.git"""
-        return urlparse(self.clone_url).path
+        if self.clone_url:
+            return urlparse(self.clone_url).path
+        else:
+            return ''
 
-    def matches(self, other_layer: 'CFSConfigurationLayer') -> bool:
-        """Determine whether this layer matches the given layer.
+    @property
+    def repo_short_name(self) -> str:
+        """a shortened version of the repo name, e.g. 'sat-config-management' becomes 'sat'"""
+        repo_name = os.path.basename(self.repo_path)
+        # Strip off the '.git' suffix then strip off '-config-management' if present
+        return strip_suffix(strip_suffix(repo_name, '.git'), '-config-management')
+
+    def matches(self, other_layer: 'CFSLayerBase') -> bool:
+        """Determine whether this layer matches another layer.
+
+        A layer matches if it has the same content, but perhaps at a different
+        version. This is useful for identifying which layers in a configuration
+        must be updated when updating the version of a product used in a CFS
+        configuration.
 
         Args:
-            other_layer: the layer data
+            other_layer: the other layer to compare
 
         Returns:
-            True if the layer matches, False otherwise.
+            True if the layers match, False otherwise.
         """
-        if not(isinstance(other_layer, CFSConfigurationLayer)):
+        # Layers must be of the same exact type to match. This means they must
+        # both be additional inventory layers or configuration layers, and they
+        # must be using the same version of CFS.
+        if type(self) is not type(other_layer):
             return False
 
-        return self.repo_path == other_layer.repo_path and self.playbook == other_layer.playbook
+        return all(getattr(self, attr) == getattr(other_layer, attr)
+                   for attr in self.MATCHING_ATTRS)
 
-    def get_updated_values(self, new_layer: 'CFSConfigurationLayer') -> Dict:
+    def get_updated_values(self, new_layer: 'CFSLayerBase') -> Dict:
         """Get the values which have been updated by the new version of this layer.
 
         Args:
@@ -164,6 +225,11 @@ class CFSConfigurationLayer:
     def resolve_branch_to_commit_hash(self) -> None:
         """Resolve a branch to a commit hash and specify only the commit hash.
 
+        CFS v3 can emulate this behavior in which branch names are resolved to
+        commit hashes and only the commit hash is stored in the configuration
+        if the 'drop_branches' request parameter is used when creating/updating
+        the configuration.
+
         Returns:
             None. Modifies `self.branch` and `self.commit`.
 
@@ -174,6 +240,12 @@ class CFSConfigurationLayer:
         if not self.branch:
             # No branch to translate to commit
             return
+
+        if self.clone_url is None:
+            # This should only be the case if this is called in CFS v3 for a layer
+            # that specifies a "source" instead of a "clone_url"
+            raise CFSConfigurationError(f'Cannot resolve branch {self.branch} to commit hash '
+                                        'because clone URL is not specified.')
 
         vcs_repo = VCSRepo(self.clone_url)
         if self.commit:
@@ -200,54 +272,64 @@ class CFSConfigurationLayer:
         Returns:
             the data for this layer in the format expected by the CFS API
         """
-        req_payload = {}
+        # Add the additional data to the payload first
+        req_payload = {**self.additional_data}
         for cfs_prop, attr in self.CFS_PROPS_TO_ATTRS.items():
             value = getattr(self, attr, None)
             if value:
-                req_payload[cfs_prop] = value
+                set_val_by_path(req_payload, cfs_prop, value)
         return req_payload
 
     def __str__(self) -> str:
-        return (f'layer with repo path {self.repo_path} and '
-                f'{f"playbook {self.playbook}" if self.playbook else "default playbook"}')
+        return f'{self.__class__.__name__} with repo path {self.repo_path}'
 
-    @staticmethod
-    def construct_name(product_or_repo: str,
-                       playbook: Optional[str] = None,
+    @classmethod
+    def from_clone_url(cls, clone_url: str,
+                       name: Optional[str] = None,
                        commit: Optional[str] = None,
-                       branch: Optional[str] = None) -> str:
-        """Construct a name for the layer following a naming convention.
+                       branch: Optional[str] = None,
+                       **kwargs: Any) -> 'CFSLayerBase':
+        """Create a new CFSConfigurationLayer from an explicit clone URL.
+
+        This method is deprecated and preserved for backwards compatibility. Use
+        the constructor directly instead.
 
         Args:
-            product_or_repo: the name of the product or repository
-            playbook: the name of the playbook
-            commit: the commit hash
-            branch: the name of the branch. If both commit and branch
-                are specified, branch is used in the name.
+            clone_url: the git repository clone URL
+            name: an optional name override
+            commit: an optional commit override
+            branch: an optional branch override
+            **kwargs: additional arguments to pass along to __init__
 
         Returns:
-            the constructed layer name
+            the layer constructed from the clone URL
         """
-        playbook_name = os.path.splitext(playbook)[0] if playbook else 'site'
-        branch_or_commit = branch or commit
-        if not branch_or_commit:
-            branch_or_commit = 'default'
+        return cls(clone_url=clone_url, name=name, commit=commit, branch=branch, **kwargs)
 
-        name_components = [
-            product_or_repo,
-            playbook_name,
-            branch_or_commit[:MAX_BRANCH_NAME_WIDTH],
-            datetime.now().strftime('%Y%m%dT%H%M%S')
-        ]
-        return '-'.join(name_components)
+    @classmethod
+    def from_cfs(cls, data: Dict) -> 'CFSLayerBase':
+        """Create a new CFSLayerBase from data in a response from CFS.
+
+        Args:
+            data: the data for the layer from CFS.
+
+        Returns:
+            the CFS configuration layer retrieved from CFS configuration data
+        """
+        data_copy = deepcopy(data)
+        kwargs = {
+            attr: pop_val_by_path(data_copy, cfs_prop)
+            for cfs_prop, attr in cls.CFS_PROPS_TO_ATTRS.items()
+        }
+        return cls(**kwargs, additional_data=data_copy)
 
     @classmethod
     def from_product_catalog(cls, product_name: str, api_gw_host: str,
                              product_version: Optional[str] = None,
-                             name: Optional[str] = None,
-                             playbook: Optional[str] = None,
                              commit: Optional[str] = None,
-                             branch: Optional[str] = None) -> 'CFSConfigurationLayer':
+                             branch: Optional[str] = None,
+                             product_catalog: Optional[ProductCatalog] = None,
+                             **kwargs: Any) -> 'CFSLayerBase':
         """Create a new CFSConfigurationLayer from product catalog data.
 
         Args:
@@ -255,10 +337,11 @@ class CFSConfigurationLayer:
             api_gw_host: the URL of the API gateway
             product_version: the version of the product in the
                 product catalog. If omitted, the latest version is used.
-            name: an optional name override
-            playbook: the name of the Ansible playbook
             commit: an optional commit override
             branch: an optional branch override
+            product_catalog: the product catalog to use. If omitted, the product
+                catalog is loaded from Kubernetes
+            **kwargs: additional keyword arguments to pass to the constructor
 
         Returns:
             the layer constructed from the product
@@ -273,108 +356,247 @@ class CFSConfigurationLayer:
             f'product {product_name}'
         )
 
+        if product_catalog is None:
+            try:
+                product_catalog = ProductCatalog()
+            except ProductCatalogError as err:
+                raise CFSConfigurationError(f'{fail_msg}: {err}')
+
         try:
-            product = ProductCatalog().get_product(product_name, product_version)
+            product = product_catalog.get_product(product_name, product_version)
         except ProductCatalogError as err:
             raise CFSConfigurationError(f'{fail_msg}: {err}')
 
         if not product.clone_url:
             raise CFSConfigurationError(f'{fail_msg}: {product} has no clone URL.')
-        else:
-            api_gw_parsed = urlparse(api_gw_host)
-            if api_gw_parsed.netloc:
-                api_gw_host = api_gw_parsed.netloc
 
-            clone_url = urlunparse(
-                urlparse(product.clone_url)._replace(
-                    netloc=api_gw_host
-                )
+        api_gw_parsed = urlparse(api_gw_host)
+        if api_gw_parsed.netloc:
+            api_gw_host = api_gw_parsed.netloc
+        clone_url = urlunparse(
+            urlparse(product.clone_url)._replace(
+                netloc=api_gw_host
             )
+        )
 
         if not (commit or branch):
             if not product.commit:
                 raise CFSConfigurationError(f'{fail_msg}: {product} has no commit hash.')
             commit = product.commit
 
-        if not name:
-            name = cls.construct_name(product_name, playbook=playbook,
-                                      commit=commit, branch=branch)
+        return cls(clone_url=clone_url, commit=commit, branch=branch, **kwargs)
 
-        return CFSConfigurationLayer(clone_url, name=name, playbook=playbook,
-                                     commit=commit, branch=branch)
 
-    @classmethod
-    def from_clone_url(cls, clone_url: str,
-                       name: Optional[str] = None,
-                       playbook: Optional[str] = None,
-                       commit: Optional[str] = None,
-                       branch: Optional[str] = None) -> 'CFSConfigurationLayer':
-        """Create a new CFSConfigurationLayer from an explicit clone URL.
+class CFSV2AdditionalInventoryLayer(CFSLayerBase):
+    """A layer of additional inventory in a CFS v2 configuration."""
+
+    CFS_PROPS_TO_ATTRS = CFSLayerBase.CFS_PROPS_TO_ATTRS.copy()
+    CFS_PROPS_TO_ATTRS['cloneUrl'] = 'clone_url'
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Create a new CFSV2AdditionalInventoryLayer.
+
+        Raises:
+            ValueError: if clone_url is not specified, or branch or commit is
+                not specified
+        """
+        super().__init__(**kwargs)
+        if not self.clone_url:
+            raise ValueError('clone_url is required for layers in CFS v2')
+
+
+class CFSV3AdditionalInventoryLayer(CFSLayerBase):
+    """A layer of additional inventory in a CFS v3 configuration."""
+
+    CFS_PROPS_TO_ATTRS = CFSLayerBase.CFS_PROPS_TO_ATTRS.copy()
+    CFS_PROPS_TO_ATTRS['clone_url'] = 'clone_url'
+    CFS_PROPS_TO_ATTRS['source'] = 'source'
+    MATCHING_ATTRS = CFSLayerBase.MATCHING_ATTRS + ['source']
+
+    def __init__(self, source: str = None, **kwargs: Any) -> None:
+        """Create a new CFSV3AdditionalInventoryLayer.
 
         Args:
-            clone_url: the git repository clone URL
-            name: an optional name override
-            playbook: the name of the Ansible playbook
-            commit: an optional commit override
-            branch: an optional branch override
+            source: the name of the CFS source to use for the layer, if not
+                using clone_url
 
-        Returns:
-            the layer constructed from the product
+        Raises:
+            ValueError: if clone_url or source is not specified, or branch or
+                commit is not specified
         """
-        def strip_suffix(s: str, suffix: str) -> str:
-            if s.endswith(suffix):
-                return s[:-len(suffix)]
-            return s
+        super().__init__(**kwargs)
+        self.source = source
+        if not (self.source or self.clone_url):
+            raise ValueError('Either source or clone_url is required for layers in CFS v3')
 
-        if not name:
-            repo_name = os.path.basename(urlparse(clone_url).path)
-            # Strip off the '.git' suffix then strip off '-config-management' if present
-            short_repo_name = strip_suffix(strip_suffix(repo_name, '.git'), '-config-management')
-            name = cls.construct_name(short_repo_name, playbook=playbook,
-                                      commit=commit, branch=branch)
+    @property
+    def repo_short_name(self) -> str:
+        """a shortened version of the repo name, or the source name"""
+        if self.source:
+            return self.source
+        else:
+            return super().repo_short_name
 
-        return CFSConfigurationLayer(clone_url, name=name, playbook=playbook,
-                                     commit=commit, branch=branch)
+    def __str__(self) -> str:
+        if self.clone_url:
+            return f'{self.__class__.__name__} with repo path {self.repo_path}'
+        else:
+            return f'{self.__class__.__name__} with source {self.source}'
 
-    @classmethod
-    def from_cfs(cls, data: Dict) -> 'CFSConfigurationLayer':
-        """Create a new CFSConfigurationLayer from data in a response from CFS.
+
+class CFSV2ConfigurationLayer(CFSV2AdditionalInventoryLayer):
+    """A layer in a CFS v2 configuration"""
+
+    CFS_PROPS_TO_ATTRS = CFSV2AdditionalInventoryLayer.CFS_PROPS_TO_ATTRS.copy()
+    CFS_PROPS_TO_ATTRS['playbook'] = 'playbook'
+    CFS_PROPS_TO_ATTRS['specialParameters.imsRequireDkms'] = 'ims_require_dkms'
+    MATCHING_ATTRS = CFSV2AdditionalInventoryLayer.MATCHING_ATTRS + ['playbook', 'ims_require_dkms']
+
+    def __init__(self, playbook: str = None, ims_require_dkms: bool = None, **kwargs: Any) -> None:
+        """Create a new CFSV2ConfigurationLayer
+
+        Note that CFS v2 configuration layers do not require a playbook. If a
+        playbook is not specified, they use the globally configured default
+        playbook.
 
         Args:
-            data: the data for the layer from CFS.
+            playbook: the name of the playbook to use for the layer
+            ims_require_dkms: a special parameter for IMS that indicates whether
+                DKMS is required for the layer
+            **kwargs: additional arguments to pass to the constructor
 
-        Returns:
-            the CFS configuration layer retrieved from CFS configuration data
+        Raises:
+            ValueError: if clone_url is not specified, or branch or commit is
+                not specified
         """
-        clone_url = data['cloneUrl']
-        kwargs = {
-            attr: data.get(cfs_prop)
-            for cfs_prop, attr in cls.CFS_PROPS_TO_ATTRS.items()
-            if cfs_prop != 'cloneUrl'
-        }
-        return cls(clone_url, **kwargs)
+        super().__init__(**kwargs)
+        self.playbook = playbook
+        self.ims_require_dkms = ims_require_dkms
+
+    def __str__(self) -> str:
+        return (f'{self.__class__.__name__} with repo path {self.repo_path}'
+                f' and {f"playbook {self.playbook}" if self.playbook else "default playbook"}')
+
+    @property
+    def name(self) -> str:
+        """the name of the CFS configuration layer"""
+        if self._name is not None:
+            return self._name
+
+        if self.playbook is not None:
+            playbook_name = os.path.splitext(self.playbook)[0]
+        else:
+            playbook_name = 'site'
+
+        branch_or_commit = self.branch or self.commit
+        # This shouldn't happen given that __init__ checks that one is specified,
+        # but program defensively and satisfy mypy type-checking.
+        if not branch_or_commit:
+            branch_or_commit = 'default'
+
+        name_components = [
+            self.repo_short_name,
+            playbook_name,
+            branch_or_commit[:MAX_BRANCH_NAME_WIDTH],
+            datetime.now().strftime('%Y%m%dT%H%M%S')
+        ]
+        return '-'.join(name_components)
 
 
-class CFSConfiguration:
-    """Represents a single configuration in CFS."""
+# This preserves backwards-compatibility with earlier versions of this library
+# which did not distinguish between CFS API versions
+CFSConfigurationLayer = CFSV2ConfigurationLayer
 
-    def __init__(self, cfs_client: 'CFSClient', data: Dict) -> None:
+
+class CFSV3ConfigurationLayer(CFSV3AdditionalInventoryLayer):
+    """A layer in a CFS v3 configuration."""
+
+    CFS_PROPS_TO_ATTRS = CFSV3AdditionalInventoryLayer.CFS_PROPS_TO_ATTRS.copy()
+    CFS_PROPS_TO_ATTRS['playbook'] = 'playbook'
+    CFS_PROPS_TO_ATTRS['special_parameters.ims_require_dkms'] = 'ims_require_dkms'
+    MATCHING_ATTRS = CFSV3AdditionalInventoryLayer.MATCHING_ATTRS + ['playbook', 'ims_require_dkms']
+
+    def __init__(self, playbook: str, ims_require_dkms: bool = None, **kwargs: Any) -> None:
+        """Create a new CFSV3ConfigurationLayer.
+
+        Args:
+            playbook: the name of the playbook to use for the layer
+            ims_require_dkms: a special parameter for IMS that indicates whether
+                DKMS is required for the layer
+
+        Raises:
+            ValueError: if clone_url or source is not specified, or branch or
+                commit is not specified
+        """
+        super().__init__(**kwargs)
+        self.playbook = playbook
+        self.ims_require_dkms = ims_require_dkms
+
+    def __str__(self) -> str:
+        if self.clone_url:
+            desc = f'{self.__class__.__name__} with repo path {self.repo_path}'
+        else:
+            desc = f'{self.__class__.__name__} with source {self.source}'
+        return f'{desc} and playbook {self.playbook}'
+
+    @property
+    def name(self) -> str:
+        """the name of the CFS configuration layer"""
+        if self._name is not None:
+            return self._name
+
+        playbook_name = os.path.splitext(self.playbook)[0]
+        branch_or_commit = self.branch or self.commit
+        # This shouldn't happen given that __init__ checks that one is specified,
+        # but program defensively and satisfy mypy type-checking.
+        if not branch_or_commit:
+            branch_or_commit = 'default'
+
+        name_components = [
+            self.repo_short_name,
+            playbook_name,
+            branch_or_commit[:MAX_BRANCH_NAME_WIDTH],
+            datetime.now().strftime('%Y%m%dT%H%M%S')
+        ]
+        return '-'.join(name_components)
+
+
+class CFSConfigurationBase(ABC):
+    """Represents a single configuration in CFS.
+
+    This abstract base class is subclassed to create the CFS v2- v3-specific
+    classes.
+    """
+
+    # Subclasses must set these class variables to the appropriate classes
+    cfs_config_layer_cls: type[CFSLayerBase]
+    cfs_additional_inventory_cls: type[CFSLayerBase]
+
+    def __init__(self, cfs_client: 'CFSClientBase', data: Dict) -> None:
+        """Create a new CFSConfiguration.
+
+        Args:
+            cfs_client: the CFSClient instance to use for interacting with CFS
+            data: the data for the configuration from CFS
+        """
         self._cfs_client = cfs_client
         self.data = data
-        self.layers = [CFSConfigurationLayer.from_cfs(layer_data)
+        self.layers = [self.cfs_config_layer_cls.from_cfs(layer_data)
                        for layer_data in self.data.get('layers', [])]
+        self.additional_inventory: Optional[CFSLayerBase] = None
+        if 'additional_inventory' in self.data:
+            self.additional_inventory = self.cfs_additional_inventory_cls.from_cfs(
+                self.data['additional_inventory'])
         self.changed = False
 
     @classmethod
-    def empty(cls, cfs_client: 'CFSClient') -> 'CFSConfiguration':
+    def empty(cls, cfs_client: 'CFSClientBase') -> 'CFSConfigurationBase':
         """Get a new empty CFSConfiguration with no layers.
 
         Returns:
             a new empty configuration
         """
-        return cls(cfs_client, {
-            'layers': []
-        })
+        return cls(cfs_client, {})
 
     @property
     def name(self) -> Optional[str]:
@@ -382,12 +604,33 @@ class CFSConfiguration:
         return self.data.get('name')
 
     @property
+    def passthrough_data(self) -> dict[str, Any]:
+        """a dict containing any additional data to pass through to CFS
+
+        This preserves any additional data that should be maintained when making
+        a PUT request to update the configuration in CFS. Currently, the only
+        field that will be saved here is "description", but this safeguards
+        against any additional fields that may be added by CFS in the future.
+        """
+        # Note: both the CFS v2 and v3 versions of the lastUpdated field are ignored
+        return {key: value for key, value in self.data.items()
+                if key not in ('layers', 'additional_inventory', 'lastUpdated',
+                               'last_updated', 'name')}
+
+    @property
     def req_payload(self) -> Dict:
-        """a dict containing just the layers key used to update in requests"""
-        return {'layers': [layer.req_payload for layer in self.layers]}
+        """the request payload to provide in a PUT request to create/update the configuration"""
+        payload: Dict = {
+            'layers': [layer.req_payload for layer in self.layers],
+        }
+        if self.additional_inventory:
+            payload['additional_inventory'] = self.additional_inventory.req_payload
+        payload.update(self.passthrough_data)
+        return payload
 
     def save_to_cfs(self, name: Optional[str] = None,
-                    overwrite: bool = True, backup_suffix: Union[str, None] = None) -> 'CFSConfiguration':
+                    overwrite: bool = True, backup_suffix: Union[str, None] = None,
+                    request_params: Dict = None) -> 'CFSConfigurationBase':
         """Save the configuration to CFS, optionally with a new name.
 
         Args:
@@ -400,6 +643,9 @@ class CFSConfiguration:
             backup_suffix: if specified, before saving the current version of
                 the CFS configuration, if it already exists in CFS, save a
                 backup with the given suffix.
+            request_params: request parameters passed along to CFS when saving
+                the new CFS configuration (e.g. drop_branches). Not passed when
+                saving the backup.
 
         Returns:
             the new configuration that was saved to CFS
@@ -445,24 +691,23 @@ class CFSConfiguration:
                                             f'and will not be overwritten.')
             if backup_suffix:
                 backup_config_name = f'{cfs_name}{backup_suffix}'
+                # CFS does not allow certain read-only properties in a PUT request, so strip them
+                for prop in ('name', 'lastUpdated', 'last_updated'):
+                    existing_cfs_config_data.pop(prop, None)
                 try:
-                    backup_config = CFSConfiguration(self._cfs_client, existing_cfs_config_data)
-                    backup_config.save_to_cfs(name=backup_config_name)
-                except CFSConfigurationError as err:
+                    self._cfs_client.put_configuration(backup_config_name, existing_cfs_config_data)
+                except APIError as err:
                     raise CFSConfigurationError(f'Failed to back up CFS configuration "{cfs_name}" '
                                                 f'to "{backup_config_name}": {err}') from err
 
         try:
-            response_json = self._cfs_client.put('configurations', cfs_name,
-                                                 json=self.req_payload).json()
+            response_json = self._cfs_client.put_configuration(
+                cfs_name, self.req_payload, request_params=request_params)
         except APIError as err:
-            raise CFSConfigurationError(f'Failed to update CFS configuration "{cfs_name}": {err}')
-        except ValueError as err:
-            raise CFSConfigurationError(f'Failed to decode JSON response from updating '
-                                        f'CFS configuration "{cfs_name}": {err}')
+            raise CFSConfigurationError(str(err)) from err
 
         LOGGER.info('Successfully saved CFS configuration "%s"', cfs_name)
-        return CFSConfiguration(self._cfs_client, response_json)
+        return self.__class__(self._cfs_client, response_json)
 
     def save_to_file(self, file_path: str, overwrite: bool = True,
                      backup_suffix: Union[str, None] = None) -> None:
@@ -505,7 +750,8 @@ class CFSConfiguration:
         except OSError as err:
             raise CFSConfigurationError(f'Failed to write to file file_path: {err}')
 
-    def ensure_layer(self, layer: CFSConfigurationLayer, state: LayerState = LayerState.PRESENT) -> None:
+    def ensure_layer(self, layer: CFSLayerBase,
+                     state: LayerState = LayerState.PRESENT) -> None:
         """Ensure a layer exists or does not exist with the given parameters.
 
         Args:
@@ -535,6 +781,9 @@ class CFSConfiguration:
                     for updated_prop, update in updated_props.items():
                         LOGGER.info('Property "%s" of %s updated from %s to %s',
                                     updated_prop, existing_layer, update[0], update[1])
+
+                # Preserve any existing additional data in the layer
+                layer.additional_data = deepcopy(existing_layer.additional_data)
                 new_layers.append(layer)
             else:
                 # This layer doesn't match, so leave it untouched
@@ -553,8 +802,30 @@ class CFSConfiguration:
             LOGGER.info('No changes to configuration "%s" are necessary.', self.name)
 
 
+class CFSV2Configuration(CFSConfigurationBase):
+    """CFS V2 configuration"""
+
+    cfs_config_layer_cls = CFSV2ConfigurationLayer
+    cfs_additional_inventory_cls = CFSV2AdditionalInventoryLayer
+
+
+# This preserves backwards-compatibility with earlier versions of this library
+# which did not distinguish between CFS API versions
+CFSConfiguration = CFSV2Configuration
+
+
+class CFSV3Configuration(CFSConfigurationBase):
+    """CFS V3 configuration"""
+
+    cfs_config_layer_cls = CFSV3ConfigurationLayer
+    cfs_additional_inventory_cls = CFSV3AdditionalInventoryLayer
+
+
 class CFSImageConfigurationSession:
     """A class representing an image customization CFS configuration session
+
+    The same class is used for both CFS v2 and v3 since the only difference here
+    is the property name for the start time.
 
     Attributes:
         data: the data from the CFS API for this session
@@ -575,7 +846,7 @@ class CFSImageConfigurationSession:
     PENDING_VALUE = 'pending'
     # Value reported by CFS in status.session.succeeded when session has succeeded
     SUCCEEDED_VALUE = 'true'
-    # Hardcode the namespace in which kuberenetes jobs are created since CFS
+    # Hardcode the namespace in which Kubernetes jobs are created since CFS
     # sessions do not record this information
     KUBE_NAMESPACE = 'services'
 
@@ -585,7 +856,7 @@ class CFSImageConfigurationSession:
     CONTAINER_SUCCEEDED_VALUE = 'succeeded'
     CONTAINER_FAILED_VALUE = 'failed'
 
-    def __init__(self, data: Dict, cfs_client: 'CFSClient', image_name: str):
+    def __init__(self, data: Dict, cfs_client: 'CFSClientBase', image_name: str):
         """Create a new CFSImageConfigurationSession
 
         Args:
@@ -648,7 +919,10 @@ class CFSImageConfigurationSession:
     @property
     def start_time(self) -> datetime:
         """The start time of this CFS session"""
+        # In CFS v2, the property is startTime. In CFS v3, it's start_time
         start_time_str = get_val_by_path(self.data, 'status.session.startTime')
+        if start_time_str is None:
+            start_time_str = get_val_by_path(self.data, 'status.session.start_time')
         # Once we can rely on Python 3.7 or greater, can switch this to use fromisoformat
         return datetime.strptime(str(start_time_str), '%Y-%m-%dT%H:%M:%S')
 
@@ -782,7 +1056,7 @@ class CFSImageConfigurationSession:
         Returns:
             One of 'running', 'waiting', 'succeeded', or 'failed'
         """
-        # The Python Kuberenetes client docs are misleading in that they
+        # The Python Kubernetes client docs are misleading in that they
         # imply only one of these keys will be present, but in reality,
         # they are all present, and set to None if not the current state
         if not container_status.state:
@@ -885,7 +1159,7 @@ class CFSImageConfigurationSession:
                 status_by_name[container_name] = status
 
         if state_log_msgs:
-            LOGGER.info(f'CFS session: {self.name: <{CFSClient.MAX_SESSION_NAME_LENGTH}} '
+            LOGGER.info(f'CFS session: {self.name: <{CFSClientBase.MAX_SESSION_NAME_LENGTH}} '
                         f'Image: {self.image_name}:')
             for msg in state_log_msgs:
                 LOGGER.info(f'    {msg}')
@@ -947,9 +1221,25 @@ class CFSImageConfigurationSession:
             self.update_pod_status(kube_client)
 
 
-class CFSClient(APIGatewayClient):
-    base_resource_path = 'cfs/v2/'
+class CFSClientBase(APIGatewayClient, ABC):
     MAX_SESSION_NAME_LENGTH = 45
+    configuration_cls: Type[CFSConfigurationBase]
+
+    @staticmethod
+    @abstractmethod
+    def join_words(*words: str) -> str:
+        """Join words together according to the convention used by the CFS version.
+
+        E.g. CFS v2 uses camelCase while CFS v3 uses snake_case
+
+        Args:
+            *words: the words to join together
+
+        Returns:
+            The words joined together according to the convention of the CFS API
+            version.
+        """
+        pass
 
     @staticmethod
     def get_valid_session_name(prefix: str = 'sat') -> str:
@@ -975,7 +1265,7 @@ class CFSClient(APIGatewayClient):
         uuid_str = str(uuid.uuid4())
 
         # Subtract an additional 1 to account for "-" separating prefix from uuid
-        prefix_max_len = CFSClient.MAX_SESSION_NAME_LENGTH - len(uuid_str) - 1
+        prefix_max_len = CFSClientBase.MAX_SESSION_NAME_LENGTH - len(uuid_str) - 1
         if len(prefix) > prefix_max_len:
             LOGGER.warning(f'Given CFS session prefix is too long and will be '
                            f'truncated ({len(prefix)} > {prefix_max_len})')
@@ -1028,22 +1318,34 @@ class CFSClient(APIGatewayClient):
         else:
             return api_version >= VersionInfo(1, 12, 0)
 
-    def put_configuration(self, config_name: str, request_body: Dict) -> None:
+    def put_configuration(self, config_name: str, request_body: Dict,
+                          request_params: Optional[Dict] = None) -> Dict:
         """Create a new configuration or update an existing configuration
 
         Args:
             config_name: the name of the configuration to create/update
             request_body: the configuration data, which should have a
                 'layers' key.
+            request_params: the parameters to pass
+
+        Returns:
+            The details of the newly updated or created session
         """
-        self.put('configurations', config_name, json=request_body)
+        try:
+            return self.put('configurations', config_name, json=request_body,
+                            req_param=request_params).json()
+        except APIError as err:
+            raise APIError(f'Failed to update CFS configuration {config_name}: {err}')
+        except ValueError as err:
+            raise APIError(f'Failed to parse JSON in response from CFS when updating '
+                           f'CFS configuration {config_name}: {err}')
 
     def get_session(self, name: str) -> Dict:
         """Get details for a session.
 
         Args:
             name: the name of the session to get
-k
+
         Returns:
             The details about the session
         """
@@ -1080,7 +1382,7 @@ k
         """
         request_body: Dict = {
             'name': session_name,
-            'configurationName': config_name,
+            self.join_words('configuration', 'name'): config_name,
             'target': {
                 'definition': 'image',
                 'groups': [
@@ -1105,7 +1407,7 @@ k
 
         return CFSImageConfigurationSession(created_session, self, image_name)
 
-    def get_configuration(self, name: str) -> CFSConfiguration:
+    def get_configuration(self, name: str) -> CFSConfigurationBase:
         """Get a CFS configuration by name."""
         try:
             config_data = self.get('configurations', name).json()
@@ -1114,10 +1416,11 @@ k
         except json.JSONDecodeError as err:
             raise APIError(f'Invalid JSON response received from CFS when getting '
                            f'configuration "{name}" from CFS: {err}')
-        return CFSConfiguration(self, config_data)
+        # Return an appropriate CFS configuration
+        return self.configuration_cls(self, config_data)
 
-    def get_configurations_for_components(self, hsm_client: HSMClient, **kwargs: str) -> List[CFSConfiguration]:
-        """Configurations for components matching the given params.
+    def get_configurations_for_components(self, hsm_client: HSMClient, **kwargs: str) -> List[CFSConfigurationBase]:
+        """Get configurations for components matching the given params.
 
         Parameters passed into this function should be valid HSM component
         attributes.
@@ -1136,13 +1439,14 @@ k
         """
         target_xnames = hsm_client.get_component_xnames(params=kwargs or None)
 
-        LOGGER.info('Querying CFS configurations for the following NCNs: %s',
+        LOGGER.info('Querying CFS configurations for the following components: %s',
                     ', '.join(target_xnames))
 
         desired_config_names = set()
         for xname in target_xnames:
             try:
-                desired_config_name = self.get('components', xname).json().get('desiredConfig')
+                desired_config_name = self.get('components', xname).json().get(
+                    self.join_words('desired', 'config'))
                 if desired_config_name:
                     LOGGER.info('Found configuration "%s" for component %s',
                                 desired_config_name, xname)
@@ -1156,6 +1460,20 @@ k
 
         return [self.get_configuration(config_name) for config_name in desired_config_names]
 
+    @abstractmethod
+    def get_components(self, params: Dict = None) -> Generator[Dict, None, None]:
+        """Get all the CFS components.
+
+        This method must handle paging if necessary.
+
+        Args:
+            params: the parameters to pass to the GET on components
+
+        Yields:
+            The CFS components.
+        """
+        pass
+
     def get_component_ids_using_config(self, config_name: str) -> List[str]:
         """Get a list of CFS components using the given CFS configuration.
 
@@ -1167,13 +1485,12 @@ k
             The list of component IDs of CFS components using the given CFS
             configuration as their desiredConfig.
         """
+        filter_params = {self.join_words('config', 'name'): config_name}
         try:
-            components = self.get('components', params={'configName': config_name}).json()
+            return [component['id'] for component in self.get_components(params=filter_params)]
         except (APIError, ValueError) as err:
             raise APIError(f'Failed to get components using configuration '
                            f'"{config_name}": {err}') from err
-        try:
-            return [component['id'] for component in components]
         except KeyError as err:
             raise APIError(f'Failed to get components using configuration "{config_name}: '
                            f'one or more components missing {err} property') from err
@@ -1197,16 +1514,64 @@ k
         """
         patch_params: Dict = {}
         if desired_config is not None:
-            patch_params['desiredConfig'] = desired_config
+            patch_params[self.join_words('desired', 'config')] = desired_config
         if enabled is not None:
             patch_params['enabled'] = enabled
         if clear_state:
             patch_params['state'] = []
         if clear_error:
-            patch_params['errorCount'] = 0
+            patch_params[self.join_words('error', 'count')] = 0
 
         if patch_params:
             self.patch('components', component_id, json=patch_params)
         else:
             LOGGER.warning(f'No property changes were requested during update '
                            f'of CFS component with id {component_id}.')
+
+
+class CFSV2Client(CFSClientBase):
+    base_resource_path = 'cfs/v2'
+    configuration_cls = CFSV2Configuration
+
+    @staticmethod
+    def join_words(*words: str) -> str:
+        return ''.join([words[0].lower()] + [word.capitalize() for word in words[1:]])
+
+    def get_components(self, params: Dict = None) -> Generator[Dict, None, None]:
+        try:
+            yield from self.get('components', params=params).json()
+        except APIError as err:
+            raise APIError(f'Failed to get CFS components: {err}')
+        except ValueError as err:
+            raise APIError(f'Failed to parse JSON in response from CFS when getting '
+                           f'components: {err}')
+
+
+# Create an alias for CFSClient that points at CFSV2Client to preserve backwards compatibility
+CFSClient = CFSV2Client
+
+
+class CFSV3Client(CFSClientBase):
+    base_resource_path = 'cfs/v3'
+    configuration_cls = CFSV3Configuration
+
+    @staticmethod
+    def join_words(*words: str) -> str:
+        return '_'.join([word.lower() for word in words])
+
+    def get_components(self, params: Dict = None) -> Generator[Dict, None, None]:
+        # On the first request, pass in user-specified parameters
+        next_params = params
+        try:
+            while True:
+                response = self.get('components', params=next_params).json()
+                yield from response['components']
+                # The CFS API preserves user-specified parameters and adds pagination parameters
+                next_params = response.get('next')
+                if not next_params:
+                    break
+        except APIError as err:
+            raise APIError(f'Failed to get CFS components: {err}')
+        except ValueError as err:
+            raise APIError(f'Failed to parse JSON in response from CFS when getting '
+                           f'components: {err}')

--- a/csm_api_client/service/gateway.py
+++ b/csm_api_client/service/gateway.py
@@ -126,6 +126,7 @@ class APIGatewayClient:
         *args: str,
         req_type: str = 'GET',
         req_param: Optional[Dict] = None,
+        req_body: Optional[Dict] = None,
         json: Dict = None,
         raise_not_ok: bool = True,
     ) -> Response:
@@ -133,10 +134,11 @@ class APIGatewayClient:
         Args:
             *args: Variable length list of path components used to construct
                 the path to the resource.
-            req_type: Type of reqest (GET, STREAM, POST, PUT, or DELETE).
-            req_param: Parameter(s) depending on request type.
+            req_type: Type of request (GET, STREAM, POST, PUT, or DELETE).
+            req_param: request parameters
+            req_body: request body
             json: The data dict to encode as JSON and pass as the body of
-                a POST request.
+                a POST, PUT, or PATCH request.
             raise_not_ok: If True and the response code is >=400, raise
                 an APIError. If False, return the response object.
 
@@ -167,11 +169,11 @@ class APIGatewayClient:
             elif req_type == 'STREAM':
                 r = requester.get(url, params=req_param, stream=True, timeout=self.timeout)
             elif req_type == 'POST':
-                r = requester.post(url, data=req_param, json=json, timeout=self.timeout)
+                r = requester.post(url, data=req_body, params=req_param, json=json, timeout=self.timeout)
             elif req_type == 'PUT':
-                r = requester.put(url, data=req_param, json=json, timeout=self.timeout)
+                r = requester.put(url, data=req_body, params=req_param, json=json, timeout=self.timeout)
             elif req_type == 'PATCH':
-                r = requester.patch(url, data=req_param, json=json, timeout=self.timeout)
+                r = requester.patch(url, data=req_body, params=req_param, json=json, timeout=self.timeout)
             elif req_type == 'DELETE':
                 r = requester.delete(url, timeout=self.timeout)
             else:
@@ -251,7 +253,7 @@ class APIGatewayClient:
                 raises a RequestException of any kind.
         """
 
-        r = self._make_req(*args, req_type='POST', req_param=payload, json=json, **kwargs)
+        r = self._make_req(*args, req_type='POST', req_body=payload, json=json, **kwargs)
 
         return r
 
@@ -272,7 +274,7 @@ class APIGatewayClient:
                 raises a RequestException of any kind.
         """
 
-        r = self._make_req(*args, req_type='PUT', req_param=payload, json=json, **kwargs)
+        r = self._make_req(*args, req_type='PUT', req_body=payload, json=json, **kwargs)
 
         return r
 
@@ -293,7 +295,7 @@ class APIGatewayClient:
                 raises a RequestException of any kind.
         """
 
-        r = self._make_req(*args, req_type='PATCH', req_param=payload, json=json, **kwargs)
+        r = self._make_req(*args, req_type='PATCH', req_body=payload, json=json, **kwargs)
 
         return r
 

--- a/csm_api_client/util.py
+++ b/csm_api_client/util.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -75,6 +75,44 @@ def get_val_by_path(
     return current_val
 
 
+# Add a function called pop_val_by_path that removes a dotted path value from a dictionary
+def pop_val_by_path(dict_val: dict, dotted_path: str, default_value: Optional[Any] = None) -> Any:
+    """Remove a value from a dictionary using a dotted path.
+
+    For example, if `dict_val` is as follows:
+
+        dict_val = {
+            'price_is_right': {
+                'host': 'Bob Barker'
+            }
+        }
+
+    Then the following call:
+
+        pop_val_by_path(dict_val, 'price_is_right.host')
+
+    Would return 'Bob Barker' and result in this dictionary:
+
+        dict_val = {
+            'price_is_right': {}
+        }
+
+    The dictionary `dict_val` is modified in place.
+    """
+    if not dotted_path:
+        raise ValueError('pop_val_by_path requires a non-empty path')
+
+    split_path = dotted_path.split('.')
+
+    for key in split_path[:-1]:
+        if not isinstance(dict_val.get(key), dict):
+            return default_value
+        dict_val = dict_val[key]
+
+    # The final key is all that remains, so pop the key
+    return dict_val.pop(split_path[-1], default_value)
+
+
 def set_val_by_path(dict_val: dict, dotted_path: str, value: Any) -> None:
     """Set a value in a dictionary using a dotted path.
 
@@ -133,3 +171,17 @@ def set_val_by_path(dict_val: dict, dotted_path: str, value: Any) -> None:
         dict_val = dict_val[key]
 
     dict_val[split_path[-1]] = value
+
+
+def strip_suffix(s: str, suffix: str) -> str:
+    """Remove a suffix from a string if it exists.
+
+    Args:
+        s: The string to remove the suffix from.
+        suffix: The suffix to remove from the string.
+    """
+    if not suffix:
+        return s
+    if s.endswith(suffix):
+        return s[:-len(suffix)]
+    return s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "2.1.1"
+version = "2.2.0"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",

--- a/tests/service/test_cfs.py
+++ b/tests/service/test_cfs.py
@@ -37,29 +37,45 @@ from cray_product_catalog.query import ProductCatalogError
 
 from csm_api_client.service.cfs import (
     CFSClient,
-    CFSConfiguration,
+    CFSV2Client,
+    CFSV3Client,
+    CFSV2Configuration,
+    CFSV3Configuration,
     CFSConfigurationError,
-    CFSConfigurationLayer,
+    CFSLayerBase,
+    CFSV2AdditionalInventoryLayer,
+    CFSV3AdditionalInventoryLayer,
+    CFSV2ConfigurationLayer,
+    CFSV3ConfigurationLayer,
     CFSImageConfigurationSession,
-    LayerState,
-    MAX_BRANCH_NAME_WIDTH,
+    LayerState
 )
 from csm_api_client.service.gateway import APIError
 from csm_api_client.service.vcs import VCSError
 
 
-class TestCFSConfigurationLayer(unittest.TestCase):
-    """Tests for the CFSConfigurationLayer class."""
+class TestCFSLayerBase(unittest.TestCase):
+    """Tests for the CFSLayerBase class."""
 
     def setUp(self):
         self.product = 'sat'
         self.repo_path = f'/vcs/cray/{self.product}-config-management.git'
         self.clone_url = f'http://api-gw-service-nmn.local{self.repo_path}'
         self.name = 'sat'
-        self.playbook = 'sat-ncn.yml'
         self.commit = 'abcd1234'
-        self.cfs_config_layer = CFSConfigurationLayer(self.clone_url, name=self.name,
-                                                      playbook=self.playbook, commit=self.commit)
+        self.additional_data = {
+            'special_parameters': {
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
+        }
+
+        # Note that it is possible to create an instance of this abstract base class
+        # only because it doesn't have any abstract methods. If one is added in the future,
+        # this test will need to create a concrete subclass to test with.
+        self.cfs_layer_cls = CFSLayerBase
+        self.cfs_layer = self.cfs_layer_cls(clone_url=self.clone_url,
+                                            name=self.name, commit=self.commit,
+                                            additional_data=self.additional_data)
 
         self.mock_vcs_repo_cls = patch('csm_api_client.service.cfs.VCSRepo').start()
         self.mock_vcs_repo = self.mock_vcs_repo_cls.return_value
@@ -72,234 +88,863 @@ class TestCFSConfigurationLayer(unittest.TestCase):
     def tearDown(self):
         patch.stopall()
 
-    def test_construct_cfs_config_layer(self):
-        """Test creating a new CFSConfigurationLayer."""
-        self.assertEqual(self.clone_url, self.cfs_config_layer.clone_url)
-        self.assertEqual(self.name, self.cfs_config_layer.name)
-        self.assertEqual(self.playbook, self.cfs_config_layer.playbook)
-        self.assertEqual(self.commit, self.cfs_config_layer.commit)
-        self.assertIsNone(self.cfs_config_layer.branch)
+    def test_init_subclass(self):
+        """Test that the __init_subclass__ method properly sets up ATTRS_TO_CFS_PROPS"""
 
-    def test_construct_cfs_configuration_layer_no_branch_commit(self):
-        """Test creating a new CFSConfigurationLayer requires a git commit or branch."""
+        # Make a concrete subclass of CFSLayerBase
+        class ConcreteCFSLayer(CFSLayerBase):
+            # Add another property like the actual subclasses do
+            CFS_PROPS_TO_ATTRS = CFSLayerBase.CFS_PROPS_TO_ATTRS.copy()
+            CFS_PROPS_TO_ATTRS['cloneUrl'] = 'clone_url'
+
+        self.assertEqual({
+            'clone_url': 'cloneUrl',
+            'commit': 'commit',
+            'branch': 'branch',
+            'name': 'name'
+        }, ConcreteCFSLayer.ATTRS_TO_CFS_PROPS)
+
+        # Ensure the base class is not modified
+        self.assertEqual({
+            'commit': 'commit',
+            'branch': 'branch',
+            'name': 'name'
+        }, CFSLayerBase.ATTRS_TO_CFS_PROPS)
+
+    def test_construct_cfs_layer(self):
+        """Test creating a new CFSConfigurationLayerBase."""
+        self.assertEqual(self.clone_url, self.cfs_layer.clone_url)
+        self.assertEqual(self.name, self.cfs_layer.name)
+        self.assertEqual(self.commit, self.cfs_layer.commit)
+        self.assertIsNone(self.cfs_layer.branch)
+        self.assertEqual(self.additional_data, self.cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_branch_only(self):
+        """Test creating a new CFSConfigurationLayerBase with only a branch."""
+        cfs_layer = self.cfs_layer_cls(clone_url=self.clone_url, name=self.name,
+                                       branch='integration')
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertIsNone(cfs_layer.commit)
+        self.assertEqual('integration', cfs_layer.branch)
+        self.assertEqual({}, cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_no_branch_commit(self):
+        """Test creating a new CFSConfigurationLayerBase requires a git commit or branch."""
         with self.assertRaisesRegex(ValueError, 'Either commit or branch is required'):
-            CFSConfigurationLayer(self.clone_url)
+            self.cfs_layer_cls(clone_url=self.clone_url)
+
+    def test_generated_name_with_commit(self):
+        """Test CFSConfigurationLayerBase.name when name is omitted and commit is specified."""
+        cfs_layer = self.cfs_layer_cls(clone_url=self.clone_url, commit='1234567abcdef')
+        self.assertEqual(f'{self.product}-1234567-{self.expected_timestamp}', cfs_layer.name)
+
+    def test_generated_name_with_branch(self):
+        """Test CFSConfigurationLayerBase.name when name is omitted and branch is specified."""
+        cfs_layer = self.cfs_layer_cls(clone_url=self.clone_url, branch='integration')
+        self.assertEqual(f'{self.product}-integra-{self.expected_timestamp}', cfs_layer.name)
 
     def test_repo_path(self):
-        """Test the repo_path property of CFSConfigurationLayer."""
-        self.assertEqual(self.repo_path, self.cfs_config_layer.repo_path)
+        """Test the repo_path property of CFSConfigurationLayerBase."""
+        self.assertEqual(self.repo_path, self.cfs_layer.repo_path)
 
-    def assert_matches(self, layer):
-        """Assert the given layer matches `self.cfs_config_layer`.
+    def test_repo_short_name(self):
+        """Test the repo_short_name property of CFSConfigurationLayerBase."""
+        self.assertEqual(self.product, self.cfs_layer.repo_short_name)
 
-        Args:
-            layer (CFSConfigurationLayer): the other layer
-        """
-        # Test that matches method is symmetric
-        self.assertTrue(self.cfs_config_layer.matches(layer))
-        self.assertTrue(layer.matches(self.cfs_config_layer))
+    def test_str(self):
+        """Test __str__ method of CFSConfigurationLayerBase."""
+        self.assertEqual(f'{self.cfs_layer_cls.__name__} with repo path {self.repo_path}',
+                         str(self.cfs_layer))
 
-    def assert_does_not_match(self, layer):
-        """Assert the given layer does not match `self.cfs_config_layer`.
-
-        Args:
-            layer: the other layer
-        """
-        self.assertFalse(self.cfs_config_layer.matches(layer))
-        self.assertFalse(layer.matches(self.cfs_config_layer))
-
-    def test_matches_matching_layer(self):
-        """Test matches method against matching CFSConfigurationLayer."""
-        matching_layer = CFSConfigurationLayer(self.clone_url, name='some-other-name',
-                                               playbook=self.playbook, branch='foo')
-        self.assert_matches(matching_layer)
-
-    def test_matches_matching_layer_different_vcs_hostname(self):
-        """Test matches method against matching CFSConfigurationLayer with different host in clone URL."""
-        matching_layer = CFSConfigurationLayer(f'http://api-gw-service.nmn{self.repo_path}',
-                                               name='matching-layer', playbook=self.playbook,
-                                               commit='a1b2c3d')
-        self.assert_matches(matching_layer)
-
-    def test_matches_mismatch_different_playbook(self):
-        """Test matches method against mismatched CFSConfigurationLayer with different playbook."""
-        mismatched_layer = CFSConfigurationLayer(self.clone_url, name=self.name,
-                                                 playbook='special.yml', commit=self.commit)
-        self.assert_does_not_match(mismatched_layer)
-
-    def test_matches_mismatch_different_repo_path(self):
-        """Test matches method against mismatched CFSConfigurationLayer with different repo path."""
-        mismatched_layer = CFSConfigurationLayer('http://api-gw-service-nmn.local/vcs/cray/mismatch.git',
-                                                 name=self.name, playbook=self.playbook,
-                                                 commit=self.commit)
-        self.assert_does_not_match(mismatched_layer)
-
-    def test_matches_mismatch_wrong_type(self):
-        """Test matches method against an incorrect type of object."""
-        self.assertFalse(self.cfs_config_layer.matches('not correct type'))
-
-    def test_get_updated_values(self):
-        """Test get_updated_values against a changed layer."""
-        new_clone_url = f'http://api-gw-service.nmn{self.repo_path}'
+    def test_get_updated_values_all_updated(self):
+        """Test get_updated_values with a layer where all attributes changed."""
         new_name = 'sat-2.3.3'
         new_commit = 'abcdef1'
-        new_layer = CFSConfigurationLayer(new_clone_url, name=new_name,
-                                          playbook=self.playbook, commit=new_commit)
-        updated_values = self.cfs_config_layer.get_updated_values(new_layer)
+        new_layer = self.cfs_layer_cls(clone_url=self.clone_url, name=new_name, commit=new_commit)
+        updated_values = self.cfs_layer.get_updated_values(new_layer)
         self.assertEqual({
-            'cloneUrl': (self.clone_url, new_clone_url),
             'name': (self.name, new_name),
+            'commit': (self.commit, new_commit)
+        }, updated_values)
+
+    def test_get_updated_values_commit_updated(self):
+        """Test get_updated_values with a layer where just the commit is updated."""
+        new_commit = '123abcd'
+        new_layer = self.cfs_layer_cls(clone_url=self.clone_url, name=self.name, commit=new_commit)
+        updated_values = self.cfs_layer.get_updated_values(new_layer)
+        self.assertEqual({
             'commit': (self.commit, new_commit)
         }, updated_values)
 
     def test_resolve_branch_no_branch(self):
         """Test resolve_branch_to_commit_hash when no branch is specified."""
-        self.cfs_config_layer.resolve_branch_to_commit_hash()
-        self.assertIsNone(self.cfs_config_layer.branch)
-        self.assertEqual(self.commit, self.cfs_config_layer.commit)
+        self.cfs_layer.resolve_branch_to_commit_hash()
+        self.assertIsNone(self.cfs_layer.branch)
+        self.assertEqual(self.commit, self.cfs_layer.commit)
         self.mock_vcs_repo_cls.assert_not_called()
 
     def test_resolve_branch_only_branch(self):
         """Test resolve_branch_to_commit_hash when only branch is specified."""
         branch = 'integration'
-        cfs_config_layer = CFSConfigurationLayer(self.clone_url, name=self.name,
-                                                 playbook=self.playbook, branch=branch)
+        cfs_layer = self.cfs_layer_cls(clone_url=self.clone_url, name=self.name,
+                                       branch=branch)
 
-        cfs_config_layer.resolve_branch_to_commit_hash()
+        cfs_layer.resolve_branch_to_commit_hash()
 
         self.mock_vcs_repo_cls.assert_called_once_with(self.clone_url)
         self.mock_vcs_repo.get_commit_hash_for_branch.assert_called_once_with(branch)
         self.assertEqual(self.mock_vcs_repo.get_commit_hash_for_branch.return_value,
-                         cfs_config_layer.commit)
-        self.assertIsNone(cfs_config_layer.branch)
+                         cfs_layer.commit)
+        self.assertIsNone(cfs_layer.branch)
 
     def test_resolve_branch_with_commit(self):
         """Test resolve_branch_to_commit_hash when branch and commit are specified."""
         branch = 'integration'
-        cfs_config_layer = CFSConfigurationLayer(self.clone_url, name=self.name,
-                                                 playbook=self.playbook, commit=self.commit,
-                                                 branch=branch)
+        cfs_layer = self.cfs_layer_cls(clone_url=self.clone_url, name=self.name,
+                                       commit=self.commit, branch=branch)
 
         with self.assertLogs(level=logging.INFO) as logs_cm:
-            cfs_config_layer.resolve_branch_to_commit_hash()
+            cfs_layer.resolve_branch_to_commit_hash()
 
         self.assertIn(f'already specifies a commit hash ({self.commit}) and branch ({branch})',
                       logs_cm.records[0].message)
         self.mock_vcs_repo_cls.assert_called_once_with(self.clone_url)
         self.mock_vcs_repo.get_commit_hash_for_branch.assert_called_once_with(branch)
         self.assertEqual(self.mock_vcs_repo.get_commit_hash_for_branch.return_value,
-                         cfs_config_layer.commit)
-        self.assertIsNone(cfs_config_layer.branch)
+                         cfs_layer.commit)
+        self.assertIsNone(cfs_layer.branch)
 
     def test_resolve_branch_does_not_exist(self):
         """Test resolve_branch_to_commit_hash when branch does not exist."""
         branch = 'integration'
-        cfs_config_layer = CFSConfigurationLayer(self.clone_url, name=self.name,
-                                                 playbook=self.playbook, branch=branch)
+        cfs_layer = self.cfs_layer_cls(clone_url=self.clone_url, name=self.name,
+                                       branch=branch)
         self.mock_vcs_repo.get_commit_hash_for_branch.return_value = None
         err_regex = f'Failed to resolve branch {branch} to commit hash. No such branch.'
 
         with self.assertRaisesRegex(CFSConfigurationError, err_regex):
-            cfs_config_layer.resolve_branch_to_commit_hash()
+            cfs_layer.resolve_branch_to_commit_hash()
 
         self.mock_vcs_repo_cls.assert_called_once_with(self.clone_url)
         self.mock_vcs_repo.get_commit_hash_for_branch.assert_called_once_with(branch)
 
         # Commit and branch should remain unaltered
-        self.assertIsNone(cfs_config_layer.commit)
-        self.assertEqual(branch, cfs_config_layer.branch)
+        self.assertIsNone(cfs_layer.commit)
+        self.assertEqual(branch, cfs_layer.branch)
 
     def test_resolve_branch_vcs_error(self):
         """Test resolve_branch_to_commit_hash when there is an error in VCSRepo."""
         branch = 'integration'
-        cfs_config_layer = CFSConfigurationLayer(self.clone_url, name=self.name,
-                                                 playbook=self.playbook, branch=branch)
-        vcs_err_msg = 'Error access VCS'
+        cfs_layer = self.cfs_layer_cls(clone_url=self.clone_url, name=self.name, branch=branch)
+        vcs_err_msg = 'Error accessing VCS'
         self.mock_vcs_repo.get_commit_hash_for_branch.side_effect = VCSError(vcs_err_msg)
         err_regex = f'Failed to resolve branch {branch} to commit hash: {vcs_err_msg}'
 
         with self.assertRaisesRegex(CFSConfigurationError, err_regex):
-            cfs_config_layer.resolve_branch_to_commit_hash()
+            cfs_layer.resolve_branch_to_commit_hash()
 
         self.mock_vcs_repo_cls.assert_called_once_with(self.clone_url)
         self.mock_vcs_repo.get_commit_hash_for_branch.assert_called_once_with(branch)
 
         # Commit and branch should remain unaltered
-        self.assertIsNone(cfs_config_layer.commit)
-        self.assertEqual(branch, cfs_config_layer.branch)
+        self.assertIsNone(cfs_layer.commit)
+        self.assertEqual(branch, cfs_layer.branch)
 
     def test_req_payload_commit_only(self):
         """Test req_payload property when only a commit hash is specified."""
         expected_payload = {
-            'cloneUrl': self.clone_url,
             'commit': self.commit,
             'name': self.name,
-            'playbook': self.playbook
         }
-        self.assertEqual(expected_payload, self.cfs_config_layer.req_payload)
+        expected_payload.update(self.additional_data)
+        self.assertEqual(expected_payload, self.cfs_layer.req_payload)
 
     def test_req_payload_branch_only(self):
         """Test req_payload property when only a branch is specified."""
         branch = 'integration'
-        cfs_config_layer = CFSConfigurationLayer(self.clone_url, name=self.name,
-                                                 playbook=self.playbook, branch=branch)
+        cfs_layer = self.cfs_layer_cls(clone_url=self.clone_url, name=self.name, branch=branch)
         expected_payload = {
-            'cloneUrl': self.clone_url,
             'branch': branch,
-            'name': self.name,
-            'playbook': self.playbook
+            'name': self.name
         }
-        self.assertEqual(expected_payload, cfs_config_layer.req_payload)
+        self.assertEqual(expected_payload, cfs_layer.req_payload)
 
     def test_req_payload_branch_and_commit(self):
         """Test req_payload when branch and commit are specified."""
         branch = 'integration'
-        cfs_config_layer = CFSConfigurationLayer(self.clone_url, name=self.name,
-                                                 playbook=self.playbook, branch=branch,
-                                                 commit=self.commit)
+        cfs_config_layer = self.cfs_layer_cls(clone_url=self.clone_url, name=self.name,
+                                              branch=branch, commit=self.commit)
         expected_payload = {
-            'cloneUrl': self.clone_url,
             'branch': branch,
             'commit': self.commit,
-            'name': self.name,
-            'playbook': self.playbook
+            'name': self.name
         }
         self.assertEqual(expected_payload, cfs_config_layer.req_payload)
 
-    def test_req_payload_only_clone_url_and_commit(self):
-        """Test req_payload when only clone URL and commit are specified."""
-        cfs_config_layer = CFSConfigurationLayer(self.clone_url, commit=self.commit)
-        expected_payload = {
-            'cloneUrl': self.clone_url,
-            'commit': self.commit
+
+class TestCFSV2AdditionalInventoryLayer(unittest.TestCase):
+    """Tests for the CFSV2AdditionalInventoryLayer class."""
+
+    def setUp(self):
+        self.product = 'sat'
+        self.repo_path = f'/vcs/cray/{self.product}-config-management.git'
+        self.clone_url = f'http://api-gw-service-nmn.local{self.repo_path}'
+        self.name = 'sat'
+        self.commit = 'abcd1234'
+        self.additional_data = {
+            'special_parameters': {
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
         }
-        self.assertEqual(expected_payload, cfs_config_layer.req_payload)
+
+    def test_construct_cfs_layer(self):
+        """Test creating a new CFSV2AdditionalInventoryLayer."""
+        cfs_layer = CFSV2AdditionalInventoryLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, additional_data=self.additional_data
+        )
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertIsNone(cfs_layer.branch)
+        self.assertEqual(self.additional_data, cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_branch_only(self):
+        """Test creating a new CFSV2AdditionalInventoryLayer with only a branch."""
+        branch = 'integration'
+        cfs_layer = CFSV2AdditionalInventoryLayer(
+            clone_url=self.clone_url, name=self.name, branch=branch
+        )
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertIsNone(cfs_layer.commit)
+        self.assertEqual(branch, cfs_layer.branch)
+        self.assertEqual({}, cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_no_branch_commit(self):
+        """Test creating a new CFSV2AdditionalInventoryLayer requires a git commit or branch."""
+        with self.assertRaisesRegex(ValueError, 'Either commit or branch is required'):
+            CFSV2AdditionalInventoryLayer(clone_url=self.clone_url)
+
+    def test_construct_cfs_layer_no_clone_url(self):
+        """Test creating a new CFSV2AdditionalInventoryLayer requires a clone URL."""
+        with self.assertRaisesRegex(ValueError, 'clone_url is required'):
+            CFSV2AdditionalInventoryLayer(name=self.name, commit=self.commit)
+
+    def test_req_payload(self):
+        """Test req_payload property of CFSV2AdditionalInventoryLayer."""
+        cfs_layer = CFSV2ConfigurationLayer(clone_url=self.clone_url, name=self.name,
+                                            commit=self.commit, additional_data=self.additional_data)
+        expected_payload = {
+            'commit': self.commit,
+            'name': self.name,
+            'cloneUrl': self.clone_url,
+            'special_parameters': {
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
+        }
+        self.assertEqual(expected_payload, cfs_layer.req_payload)
+
+    def test_from_cfs(self):
+        """Test from_cfs class method of CFSV2AdditionalInventoryLayer."""
+        cfs_layer_data = {
+            'cloneUrl': self.clone_url,
+            'commit': self.commit,
+            'name': self.name
+        }
+        cfs_layer = CFSV2AdditionalInventoryLayer.from_cfs(cfs_layer_data)
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertEqual(self.name, cfs_layer.name)
+
+
+class TestCFSV3AdditionalInventoryLayer(unittest.TestCase):
+    """Tests for the CFSV3AdditionalInventoryLayer class."""
+    def setUp(self):
+        self.product = 'sat'
+        self.repo_path = f'/vcs/cray/{self.product}-config-management.git'
+        self.clone_url = f'http://api-gw-service-nmn.local{self.repo_path}'
+        self.name = 'sat'
+        self.commit = 'abcd1234'
+        self.additional_data = {
+            'special_parameters': {
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
+        }
+
+    def test_construct_cfs_layer(self):
+        """Test creating a new CFSV3AdditionalInventoryLayer."""
+        cfs_layer = CFSV3AdditionalInventoryLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, additional_data=self.additional_data
+        )
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertIsNone(cfs_layer.source)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertIsNone(cfs_layer.branch)
+        self.assertEqual(self.additional_data, cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_branch_only(self):
+        """Test creating a new CFSV3AdditionalInventoryLayer with only a branch."""
+        branch = 'integration'
+        cfs_layer = CFSV3AdditionalInventoryLayer(
+            clone_url=self.clone_url, name=self.name, branch=branch
+        )
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertIsNone(cfs_layer.source)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertIsNone(cfs_layer.commit)
+        self.assertEqual(branch, cfs_layer.branch)
+        self.assertEqual({}, cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_source(self):
+        """Test creating a new CFSV3AdditionalInventoryLayer with a source name."""
+        cfs_layer = CFSV3AdditionalInventoryLayer(source='my-source', name=self.name,
+                                                  commit=self.commit)
+        self.assertEqual('my-source', cfs_layer.source)
+        self.assertIsNone(cfs_layer.clone_url)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertIsNone(cfs_layer.branch)
+        self.assertEqual({}, cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_no_branch_commit(self):
+        """Test creating a new CFSV3AdditionalInventoryLayer requires a git commit or branch"""
+        with self.assertRaisesRegex(ValueError, 'Either commit or branch is required'):
+            CFSV3AdditionalInventoryLayer(clone_url=self.clone_url)
+
+    def test_construct_cfs_layer_no_clone_url_or_source(self):
+        """Test creating a new CFSV3AdditionalInventoryLayer requires a clone URL or source name"""
+        with self.assertRaisesRegex(ValueError, 'source or clone_url is required'):
+            CFSV3AdditionalInventoryLayer(name=self.name, commit=self.commit)
+
+    def test_repo_short_name_with_clone_url(self):
+        """Test the repo_short_name property of CFSV3AdditionalInventoryLayer with clone_url specified"""
+        cfs_layer = CFSV3AdditionalInventoryLayer(clone_url=self.clone_url, name=self.name,
+                                                  commit=self.commit)
+        self.assertEqual(self.product, cfs_layer.repo_short_name)
+
+    def test_repo_short_name_with_source(self):
+        """Test the repo_short_name property of CFSV3AdditionalInventoryLayer with source specified"""
+        cfs_layer = CFSV3AdditionalInventoryLayer(source='my-source', name=self.name,
+                                                  commit=self.commit)
+        self.assertEqual('my-source', cfs_layer.repo_short_name)
+
+    def test_str_with_clone_url(self):
+        """Test the __str__ method with clone_url specified"""
+        cfs_layer = CFSV3AdditionalInventoryLayer(clone_url=self.clone_url, name=self.name,
+                                                  commit=self.commit)
+        self.assertEqual(f'CFSV3AdditionalInventoryLayer with repo path {self.repo_path}', str(cfs_layer))
+
+    def test_str_with_source(self):
+        """Test the __str__ method with source specified"""
+        cfs_layer = CFSV3AdditionalInventoryLayer(source='my-source', name=self.name,
+                                                  commit=self.commit)
+        self.assertEqual('CFSV3AdditionalInventoryLayer with source my-source', str(cfs_layer))
+
+    def test_req_payload(self):
+        """Test req_payload property of CFSV3AdditionalInventoryLayer."""
+        cfs_layer = CFSV3AdditionalInventoryLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, additional_data=self.additional_data
+        )
+        expected_payload = {
+            'commit': self.commit,
+            'name': self.name,
+            'clone_url': self.clone_url,
+            'special_parameters': {
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
+        }
+        self.assertEqual(expected_payload, cfs_layer.req_payload)
+
+    def test_from_cfs(self):
+        """Test from_cfs class method of CFSV3AdditionalInventoryLayer."""
+        cfs_layer_data = {
+            'clone_url': self.clone_url,
+            'commit': self.commit,
+            'name': self.name
+        }
+        cfs_layer = CFSV3AdditionalInventoryLayer.from_cfs(cfs_layer_data)
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertEqual(self.name, cfs_layer.name)
+
+
+class TestCFSV2ConfigurationLayer(unittest.TestCase):
+    """Tests for CFSV2ConfigurationLayer class."""
+
+    def setUp(self):
+        self.product = 'sat'
+        self.repo_path = f'/vcs/cray/{self.product}-config-management.git'
+        self.clone_url = f'http://api-gw-service-nmn.local{self.repo_path}'
+        self.name = 'sat'
+        self.commit = 'abcd1234'
+        self.playbook = 'do-things.yml'
+        self.additional_data = {
+            'specialParameters': {
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
+        }
+        self.mock_datetime = patch('csm_api_client.service.cfs.datetime', wraps=datetime.datetime).start()
+        self.static_datetime = datetime.datetime(2024, 8, 25, 11, 11, 11)
+        self.mock_datetime.now.return_value = self.static_datetime
+        self.expected_timestamp = '20240825T111111'
+
+    def test_construct_cfs_layer(self):
+        """Test creating a new CFSV2ConfigurationLayer."""
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook,
+            additional_data=self.additional_data
+        )
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertIsNone(cfs_layer.branch)
+        self.assertEqual(self.playbook, cfs_layer.playbook)
+        self.assertIsNone(cfs_layer.ims_require_dkms)
+        self.assertEqual(self.additional_data, cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_ims_require_dkms(self):
+        """Test creating a new CFSV2ConfigurationLayer with ims_require_dkms specified."""
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook,
+            ims_require_dkms=True,
+            additional_data=self.additional_data
+        )
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertIsNone(cfs_layer.branch)
+        self.assertEqual(self.playbook, cfs_layer.playbook)
+        self.assertTrue(cfs_layer.ims_require_dkms)
+        self.assertEqual(self.additional_data, cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_no_playbook(self):
+        """Test creating a new CFSV2ConfigurationLayer without a playbook."""
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit,
+            ims_require_dkms=True,
+            additional_data=self.additional_data
+        )
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertIsNone(cfs_layer.branch)
+        self.assertIsNone(cfs_layer.playbook)
+        self.assertTrue(cfs_layer.ims_require_dkms)
+        self.assertEqual(self.additional_data, cfs_layer.additional_data)
 
     def test_str_with_playbook(self):
-        """Test __str__ method with a playbook specified."""
-        self.assertEqual(f'layer with repo path {self.repo_path} and playbook {self.playbook}',
-                         str(self.cfs_config_layer))
+        """Test __str__ method of CFSV2ConfigurationLayer with playbook specified."""
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook
+        )
+        self.assertEqual(f'CFSV2ConfigurationLayer with repo path {self.repo_path} '
+                         f'and playbook {self.playbook}', str(cfs_layer))
 
-    def test_str_with_no_playbook(self):
-        """Test __str__ method with no playbook specified."""
-        cfs_config_layer = CFSConfigurationLayer(self.clone_url, commit=self.commit)
-        self.assertEqual(f'layer with repo path {self.repo_path} and default playbook',
-                         str(cfs_config_layer))
+    def test_str_no_playbook(self):
+        """Test __str__ method of CFSV2ConfigurationLayer without playbook specified."""
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit
+        )
+        self.assertEqual(f'CFSV2ConfigurationLayer with repo path {self.repo_path} '
+                         f'and default playbook', str(cfs_layer))
 
-    def test_construct_name_playbook_and_branch(self):
-        """Test construct_name static method with a playbook and branch."""
-        branch_name = 'integration'
-        name = CFSConfigurationLayer.construct_name(self.product, playbook=self.playbook,
-                                                    branch=branch_name)
-        expected_name = (f'{self.product}-{self.playbook[:-4]}-'
-                         f'{branch_name[:MAX_BRANCH_NAME_WIDTH]}-{self.expected_timestamp}')
-        self.assertEqual(expected_name, name)
+    def test_name_when_specified(self):
+        """Test name property of CFSV2ConfigurationLayer when name is specified."""
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook
+        )
+        self.assertEqual(self.name, cfs_layer.name)
 
-    def test_construct_name_no_playbook(self):
-        """Test construct_name static method with no playbook and a commit."""
-        name = CFSConfigurationLayer.construct_name(self.product, commit='1234567abcdef')
-        self.assertEqual(f'{self.product}-site-1234567-{self.expected_timestamp}',
-                         name)
+    def test_name_with_commit_and_playbook(self):
+        """Test name property of CFSV2ConfigurationLayer with commit and playbook specified."""
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url,
+            commit=self.commit, playbook=self.playbook
+        )
+        self.assertEqual(f'{self.product}-do-things-{self.commit[:7]}-{self.expected_timestamp}',
+                         cfs_layer.name)
+
+    def test_name_with_branch_and_playbook(self):
+        """Test name property of CFSV2ConfigurationLayer with branch and playbook specified."""
+        branch = 'integration'
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url, branch=branch,
+            playbook=self.playbook
+        )
+        self.assertEqual(f'{self.product}-do-things-{branch[:7]}-{self.expected_timestamp}',
+                         cfs_layer.name)
+
+    def test_name_no_playbook(self):
+        """Test name property of CFSV2ConfigurationLayer with no playbook specified."""
+        cfs_layer = CFSV2ConfigurationLayer(clone_url=self.clone_url, commit=self.commit)
+        self.assertEqual(f'{self.product}-site-{self.commit[:7]}-{self.expected_timestamp}',
+                         cfs_layer.name)
+
+    def test_req_payload(self):
+        """Test req_payload property of CFSV2ConfigurationLayer."""
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook,
+            additional_data={'foo': 'bar', 'baz': {'bat': 'qux'}}
+        )
+        expected_payload = {
+            'commit': self.commit,
+            'name': self.name,
+            'cloneUrl': self.clone_url,
+            'playbook': self.playbook,
+            'foo': 'bar',
+            'baz': {'bat': 'qux'}
+        }
+        self.assertEqual(expected_payload, cfs_layer.req_payload)
+
+    def test_payload_with_ims_require_dkms(self):
+        """Test req_payload property of CFSV2ConfigurationLayer with ims_require_dkms."""
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook,
+            ims_require_dkms=True, additional_data=self.additional_data
+        )
+        expected_payload = {
+            'commit': self.commit,
+            'name': self.name,
+            'cloneUrl': self.clone_url,
+            'playbook': self.playbook,
+            'specialParameters': {
+                'imsRequireDkms': True,
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
+        }
+        self.assertEqual(expected_payload, cfs_layer.req_payload)
+
+    def test_from_cfs(self):
+        """Test from_cfs class method of CFSV2ConfigurationLayer."""
+        cfs_layer_data = {
+            'cloneUrl': self.clone_url,
+            'commit': self.commit,
+            'name': self.name,
+            'playbook': self.playbook,
+            'specialParameters': { 'imsRequireDkms': True }
+        }
+        cfs_layer = CFSV2ConfigurationLayer.from_cfs(cfs_layer_data)
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertEqual(self.playbook, cfs_layer.playbook)
+        self.assertTrue(cfs_layer.ims_require_dkms)
+
+
+# Create a test class for CFSV3ConfigurationLayer just like the tests for CFSV2ConfigurationLayer
+class TestCFSV3ConfigurationLayer(unittest.TestCase):
+    """Tests for the CFSV3ConfigurationLayer class."""
+
+    def setUp(self):
+        self.product = 'sat'
+        self.repo_path = f'/vcs/cray/{self.product}-config-management.git'
+        self.clone_url = f'http://api-gw-service-nmn.local{self.repo_path}'
+        self.name = 'sat'
+        self.commit = 'abcd1234'
+        self.playbook = 'do-things.yml'
+        self.additional_data = {
+            'special_parameters': {
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
+        }
+        self.mock_datetime = patch('csm_api_client.service.cfs.datetime', wraps=datetime.datetime).start()
+        self.static_datetime = datetime.datetime(2024, 8, 25, 11, 11, 11)
+        self.mock_datetime.now.return_value = self.static_datetime
+        self.expected_timestamp = '20240825T111111'
+
+    def test_construct_cfs_layer(self):
+        """Test creating a new CFSV3ConfigurationLayer."""
+        cfs_layer = CFSV3ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook,
+            additional_data=self.additional_data
+        )
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertIsNone(cfs_layer.branch)
+        self.assertEqual(self.playbook, cfs_layer.playbook)
+        self.assertIsNone(cfs_layer.ims_require_dkms)
+        self.assertEqual(self.additional_data, cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_ims_require_dkms(self):
+        """Test creating a new CFSV3ConfigurationLayer with ims_require_dkms specified."""
+        cfs_layer = CFSV3ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook,
+            ims_require_dkms=True,
+            additional_data=self.additional_data
+        )
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertIsNone(cfs_layer.branch)
+        self.assertEqual(self.playbook, cfs_layer.playbook)
+        self.assertTrue(cfs_layer.ims_require_dkms)
+        self.assertEqual(self.additional_data, cfs_layer.additional_data)
+
+    def test_construct_cfs_layer_no_playbook(self):
+        """Test creating a new CFSV3ConfigurationLayer without a playbook."""
+        with self.assertRaisesRegex(TypeError, "missing 1 required positional argument: 'playbook'"):
+            CFSV3ConfigurationLayer(
+                clone_url=self.clone_url, name=self.name,
+                commit=self.commit, additional_data=self.additional_data
+            )
+
+    def test_str_with_clone_url(self):
+        """Test __str__ method of CFSV3ConfigurationLayer with clone_url specified."""
+        cfs_layer = CFSV3ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook
+        )
+        self.assertEqual(f'CFSV3ConfigurationLayer with repo path {self.repo_path} '
+                         f'and playbook {self.playbook}', str(cfs_layer))
+
+    def test_str_with_source(self):
+        """Test __str__ method of CFSV3ConfigurationLayer with source specified."""
+        cfs_layer = CFSV3ConfigurationLayer(
+            source='my-source', name=self.name,
+            commit=self.commit, playbook=self.playbook
+        )
+        self.assertEqual('CFSV3ConfigurationLayer with source my-source '
+                         f'and playbook {self.playbook}', str(cfs_layer))
+
+    def test_name_when_specified(self):
+        """Test name property of CFSV3ConfigurationLayer when name is specified."""
+        cfs_layer = CFSV3ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook
+        )
+        self.assertEqual(self.name, cfs_layer.name)
+
+    def test_name_with_commit_and_playbook(self):
+        """Test name property of CFSV3ConfigurationLayer with commit and playbook specified."""
+        cfs_layer = CFSV3ConfigurationLayer(
+            clone_url=self.clone_url,
+            commit=self.commit, playbook=self.playbook
+        )
+        self.assertEqual(f'{self.product}-do-things-{self.commit[:7]}-{self.expected_timestamp}',
+                         cfs_layer.name)
+
+    def test_name_with_branch_and_playbook(self):
+        """Test name property of CFSV3ConfigurationLayer with branch and playbook specified."""
+        branch = 'integration'
+        cfs_layer = CFSV3ConfigurationLayer(
+            clone_url=self.clone_url, branch=branch,
+            playbook=self.playbook
+        )
+        self.assertEqual(f'{self.product}-do-things-{branch[:7]}-{self.expected_timestamp}',
+                         cfs_layer.name)
+
+    def test_req_payload(self):
+        """Test req_payload property of CFSV2ConfigurationLayer."""
+        cfs_layer = CFSV3ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook,
+            additional_data={'foo': 'bar', 'baz': {'bat': 'qux'}}
+        )
+        expected_payload = {
+            'commit': self.commit,
+            'name': self.name,
+            'clone_url': self.clone_url,
+            'playbook': self.playbook,
+            'foo': 'bar',
+            'baz': {'bat': 'qux'}
+        }
+        self.assertEqual(expected_payload, cfs_layer.req_payload)
+
+    def test_payload_with_ims_require_dkms(self):
+        """Test req_payload property of CFSV2ConfigurationLayer with ims_require_dkms."""
+        cfs_layer = CFSV3ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook,
+            ims_require_dkms=True, additional_data=self.additional_data
+        )
+        expected_payload = {
+            'commit': self.commit,
+            'name': self.name,
+            'clone_url': self.clone_url,
+            'playbook': self.playbook,
+            'special_parameters': {
+                'ims_require_dkms': True,
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
+        }
+        self.assertEqual(expected_payload, cfs_layer.req_payload)
+
+    def test_from_cfs(self):
+        """Test from_cfs class method of CFSV3ConfigurationLayer."""
+        cfs_layer_data = {
+            'clone_url': self.clone_url,
+            'commit': self.commit,
+            'name': self.name,
+            'playbook': self.playbook,
+            'special_parameters': { 'ims_require_dkms': True }
+        }
+        cfs_layer = CFSV3ConfigurationLayer.from_cfs(cfs_layer_data)
+        self.assertEqual(self.clone_url, cfs_layer.clone_url)
+        self.assertEqual(self.commit, cfs_layer.commit)
+        self.assertEqual(self.name, cfs_layer.name)
+        self.assertEqual(self.playbook, cfs_layer.playbook)
+        self.assertTrue(cfs_layer.ims_require_dkms)
+
+
+class TestCFSLayersMatch(unittest.TestCase):
+    """Tests for the matches method of CFSLayerBase subclasses."""
+
+    def setUp(self):
+        self.clone_url = 'http://api-gw-service-nmn.local/vcs/cray/sat-config-management.git'
+        self.clone_url_diff_host = 'http://api-gw-service.nmn.local/vcs/cray/sat-config-management.git'
+        self.other_clone_url = 'http://api-gw-service.nmn.local/vcs/cray/other-config-management.git'
+        self.playbook = 'do-things.yml'
+        self.other_playbook = 'do-other-things.yml'
+
+    def assert_matches(self, layer_1, layer_2):
+        """Assert the given layer matches `self.cfs_config_layer`.
+
+        Args:
+            layer_1: the first layer
+            layer_2: the second layer
+        """
+        # Check both ways to ensure symmetric relationship
+        self.assertTrue(layer_1.matches(layer_2))
+        self.assertTrue(layer_2.matches(layer_1))
+
+    def assert_does_not_match(self, layer_1, layer_2):
+        """Assert the given layer does not match `self.cfs_config_layer`.
+
+        Args:
+            layer_1: the first layer
+            layer_2: the second layer
+        """
+        # Check both ways to ensure symmetric relationship
+        self.assertFalse(layer_1.matches(layer_2))
+        self.assertFalse(layer_2.matches(layer_1))
+
+    def test_additional_inventory_layers_match(self):
+        """Test matches method against matching additional inventory layers"""
+        for layer_cls in [CFSV2AdditionalInventoryLayer, CFSV3AdditionalInventoryLayer]:
+            # Two layers with the same clone_url and name should match
+            layer_1 = layer_cls(clone_url=self.clone_url, name='sat', commit='abcd1234')
+            layer_2 = layer_cls(clone_url=self.clone_url_diff_host, name='sat', commit='5678aef')
+            self.assert_matches(layer_1, layer_2)
+
+    def test_additional_inventory_layers_do_not_match(self):
+        """Test matches method against non-matching additional inventory layers"""
+        for layer_cls in [CFSV2AdditionalInventoryLayer, CFSV3AdditionalInventoryLayer]:
+            non_matching_pairs = (
+                (layer_cls(clone_url=self.clone_url, name='first', commit='abcd1234'),
+                 layer_cls(clone_url=self.other_clone_url, name='second', commit='abcd1234')),
+            )
+            for layer_1, layer_2 in non_matching_pairs:
+                self.assert_does_not_match(layer_1, layer_2)
+
+    def test_additional_inventory_layers_v3_with_source_matches(self):
+        """Test matches against CFSV3AdditionalInventoryLayer with source name."""
+        layer_1 = CFSV3AdditionalInventoryLayer(source='my-source', name='sat', commit='abcd1234')
+        layer_2 = CFSV3AdditionalInventoryLayer(source='my-source', name='sat', commit='5678aef')
+        self.assert_matches(layer_1, layer_2)
+
+    def test_additional_inventory_layers_v3_with_source_does_not_match(self):
+        layer_1 = CFSV3AdditionalInventoryLayer(source='my-source', name='sat', commit='abcd1234')
+        layer_2 = CFSV3AdditionalInventoryLayer(source='other-source', name='sat', commit='abcd1234')
+        self.assert_does_not_match(layer_1, layer_2)
+
+    def test_configuration_layers_match(self):
+        """Test matches method against matching configuration layers"""
+        for layer_cls in [CFSV2ConfigurationLayer, CFSV3ConfigurationLayer]:
+            # Two layers with the same clone_url and playbook path should match,
+            # even if the clone_url differs slightly
+            layer_1 = layer_cls(clone_url=self.clone_url, name='sat',
+                                playbook=self.playbook, commit='abcd1234')
+            layer_2 = layer_cls(clone_url=self.clone_url_diff_host, name='other-name',
+                                playbook=self.playbook, commit='5678aef')
+            self.assert_matches(layer_1, layer_2)
+
+    def test_configuration_layers_do_not_match(self):
+        """Test matches method against non-matching layers"""
+        for layer_cls in [CFSV2ConfigurationLayer, CFSV3ConfigurationLayer]:
+            non_matching_pairs = (
+                (
+                    layer_cls(clone_url=self.clone_url, name='first',
+                              playbook=self.playbook, commit='abcd1234'),
+                    layer_cls(clone_url=self.other_clone_url, name='second',
+                              playbook=self.playbook, commit='abcd1234')
+                ),
+                (
+                    layer_cls(clone_url=self.clone_url, name='first',
+                              playbook=self.playbook, commit='abcd1234'),
+                    layer_cls(clone_url=self.clone_url, name='second',
+                              playbook=self.other_playbook, commit='abcd1234')
+                ),
+                (
+                    layer_cls(clone_url=self.clone_url, name='first',
+                              playbook=self.playbook, commit='abcd1234',
+                              ims_require_dkms=True),
+                    layer_cls(clone_url=self.clone_url, name='second',
+                              playbook=self.playbook, commit='5678aef',
+                              ims_require_dkms=False)
+                ),
+            )
+            for layer_1, layer_2 in non_matching_pairs:
+                self.assert_does_not_match(layer_1, layer_2)
+
+    def test_configuration_layers_v3_with_source_matches(self):
+        """Test matches against CFSV3ConfigurationLayer with source name."""
+        layer_1 = CFSV3ConfigurationLayer(source='my-source', name='sat',
+                                          playbook=self.playbook, commit='abcd1234',
+                                          ims_require_dkms=True)
+        layer_2 = CFSV3ConfigurationLayer(source='my-source', name='sat',
+                                          playbook=self.playbook, commit='5678aef',
+                                          ims_require_dkms=True)
+        self.assert_matches(layer_1, layer_2)
+
+    def test_configuration_layers_v3_with_source_does_not_match(self):
+        layer_1 = CFSV3ConfigurationLayer(source='my-source', name='sat',
+                                          playbook=self.playbook, commit='abcd1234')
+        layer_2 = CFSV3ConfigurationLayer(source='other-source', name='sat',
+                                          playbook=self.playbook, commit='abcd1234')
+        self.assert_does_not_match(layer_1, layer_2)
+
+    def test_matches_mismatch_wrong_types(self):
+        """Test matches method against an incorrect type pairings."""
+        non_matching_pairs = (
+            (
+                CFSV2ConfigurationLayer(clone_url=self.clone_url, name='sat',
+                                        playbook=self.playbook, commit='abcd1234'),
+                CFSV2AdditionalInventoryLayer(clone_url=self.clone_url, name='sat', commit='abcd1234')
+            ),
+            (
+                CFSV3ConfigurationLayer(clone_url=self.clone_url, name='sat',
+                                        playbook=self.playbook, commit='abcd1234'),
+                CFSV3AdditionalInventoryLayer(clone_url=self.clone_url, name='sat', commit='abcd1234')
+            ),
+            (
+                CFSV2ConfigurationLayer(clone_url=self.clone_url, name='sat',
+                                        playbook=self.playbook, commit='abcd1234'),
+                CFSV3ConfigurationLayer(clone_url=self.clone_url, name='sat',
+                                        playbook=self.playbook, commit='abcd1234')
+            ),
+            (
+                CFSV2AdditionalInventoryLayer(clone_url=self.clone_url, name='sat', commit='abcd1234'),
+                CFSV3AdditionalInventoryLayer(clone_url=self.clone_url, name='sat', commit='abcd1234')
+            ),
+        )
+        for layer_1, layer2 in non_matching_pairs:
+            self.assert_does_not_match(layer_1, layer2)
 
 
 class TestCFSConfigurationLayerFromProduct(unittest.TestCase):
@@ -320,52 +965,64 @@ class TestCFSConfigurationLayerFromProduct(unittest.TestCase):
         self.mock_product.clone_url = self.clone_url
         self.mock_product.commit = self.product_commit
 
-        self.mock_construct_name = patch.object(CFSConfigurationLayer, 'construct_name').start()
-
     def tearDown(self):
         patch.stopall()
 
-    def test_product_defaults(self):
+    def test_product_defaults_with_product_catalog(self):
         """Test from_product_catalog with defaults from product entry."""
-        layer = CFSConfigurationLayer.from_product_catalog(self.product_name, self.api_gw_host,
-                                                           product_version=self.product_version)
+        layer = CFSLayerBase.from_product_catalog(self.product_name, self.api_gw_host,
+                                                  product_version=self.product_version,
+                                                  product_catalog=self.mock_product_catalog)
+        # The method should not create a new ProductCatalog instance since it was given one
+        self.mock_product_catalog_cls.assert_not_called()
         self.mock_product_catalog.get_product.assert_called_once_with(self.product_name,
                                                                       self.product_version)
         self.assertEqual(self.expected_clone_url, layer.clone_url)
         self.assertEqual(self.product_commit, layer.commit)
         self.assertIsNone(layer.branch)
-        self.assertEqual(self.mock_construct_name.return_value, layer.name)
+
+    def test_product_default_no_product_catalog(self):
+        """Test from_product_catalog with defaults from product entry when not given a product catalog."""
+        layer = CFSLayerBase.from_product_catalog(self.product_name, self.api_gw_host,
+                                                  product_version=self.product_version)
+        # The method should create a new ProductCatalog instance since it was not given one
+        self.mock_product_catalog_cls.assert_called_once_with()
+        self.mock_product_catalog.get_product.assert_called_once_with(self.product_name,
+                                                                      self.product_version)
+        self.assertEqual(self.expected_clone_url, layer.clone_url)
+        self.assertEqual(self.product_commit, layer.commit)
+        self.assertIsNone(layer.branch)
 
     def test_product_no_version_with_commit_hash(self):
         """Test from_product_catalog when a commit hash is specified."""
         alternate_commit = 'a1b2c3d'
-        layer = CFSConfigurationLayer.from_product_catalog(self.product_name, self.api_gw_host, commit=alternate_commit)
+        layer = CFSLayerBase.from_product_catalog(self.product_name, self.api_gw_host,
+                                                  commit=alternate_commit)
+        self.mock_product_catalog_cls.assert_called_once_with()
         self.mock_product_catalog.get_product.assert_called_once_with(self.product_name, None)
         self.assertEqual(self.expected_clone_url, layer.clone_url)
         self.assertEqual(alternate_commit, layer.commit)
         self.assertIsNone(layer.branch)
-        self.assertEqual(self.mock_construct_name.return_value, layer.name)
 
     def test_product_with_branch(self):
         """Test from_product_catalog when a branch is specified."""
         branch = 'integration'
-        layer = CFSConfigurationLayer.from_product_catalog(self.product_name, self.api_gw_host,
-                                                           product_version=self.product_version,
-                                                           branch=branch)
+        layer = CFSLayerBase.from_product_catalog(self.product_name, self.api_gw_host,
+                                                  product_version=self.product_version,
+                                                  branch=branch)
+        self.mock_product_catalog_cls.assert_called_once_with()
         self.mock_product_catalog.get_product.assert_called_once_with(self.product_name,
                                                                       self.product_version)
         self.assertEqual(self.expected_clone_url, layer.clone_url)
         self.assertEqual(branch, layer.branch)
         self.assertIsNone(layer.commit)
-        self.assertEqual(self.mock_construct_name.return_value, layer.name)
 
     def test_product_custom_layer_name(self):
         """Test from_product_catalog with a custom layer name."""
         custom_layer_name = f'custom-{self.product_name}'
 
-        layer = CFSConfigurationLayer.from_product_catalog(self.product_name, self.api_gw_host,
-                                                           name=custom_layer_name)
-        self.mock_construct_name.assert_not_called()
+        layer = CFSLayerBase.from_product_catalog(self.product_name, self.api_gw_host,
+                                                  name=custom_layer_name)
         self.assertEqual(self.expected_clone_url, layer.clone_url)
         self.assertEqual(self.product_commit, layer.commit)
         self.assertIsNone(layer.branch)
@@ -379,7 +1036,7 @@ class TestCFSConfigurationLayerFromProduct(unittest.TestCase):
                      f'{self.product_name}: {pc_err_msg}')
 
         with self.assertRaisesRegex(CFSConfigurationError, err_regex):
-            CFSConfigurationLayer.from_product_catalog(self.product_name, self.api_gw_host)
+            CFSLayerBase.from_product_catalog(self.product_name, self.api_gw_host)
 
     def test_product_unknown_version(self):
         """Test from_product_catalog when unable to find the requested version of the product."""
@@ -389,8 +1046,8 @@ class TestCFSConfigurationLayerFromProduct(unittest.TestCase):
                      f'of product {self.product_name}: {pc_err_msg}')
 
         with self.assertRaisesRegex(CFSConfigurationError, err_regex):
-            CFSConfigurationLayer.from_product_catalog(self.product_name, self.api_gw_host,
-                                                       product_version=self.product_version)
+            CFSLayerBase.from_product_catalog(self.product_name, self.api_gw_host,
+                                              product_version=self.product_version)
 
     def test_product_missing_commit(self):
         """Test from_product_catalog when unable to find a commit hash for the product."""
@@ -399,7 +1056,7 @@ class TestCFSConfigurationLayerFromProduct(unittest.TestCase):
                      f'{self.product_name}: .* has no commit hash')
 
         with self.assertRaisesRegex(CFSConfigurationError, err_regex):
-            CFSConfigurationLayer.from_product_catalog(self.product_name, self.api_gw_host)
+            CFSLayerBase.from_product_catalog(self.product_name, self.api_gw_host)
 
     def test_product_missing_clone_url(self):
         """Test from_product_catalog when unable to find a clone URL for the product."""
@@ -408,75 +1065,43 @@ class TestCFSConfigurationLayerFromProduct(unittest.TestCase):
                      f'{self.product_name}: .* has no clone URL')
 
         with self.assertRaisesRegex(CFSConfigurationError, err_regex):
-            CFSConfigurationLayer.from_product_catalog(self.product_name, self.api_gw_host)
+            CFSLayerBase.from_product_catalog(self.product_name, self.api_gw_host)
 
     def test_api_gw_host_with_url_scheme(self):
         """Test from_product_catalog when a URL scheme is added to the URL."""
-        layer = CFSConfigurationLayer.from_product_catalog(self.product_name, f'https://{self.api_gw_host}')
+        layer = CFSLayerBase.from_product_catalog(self.product_name, f'https://{self.api_gw_host}')
         self.assertEqual(layer.clone_url, self.expected_clone_url)
 
 
 class TestCFSConfigurationLayerFromCloneUrl(unittest.TestCase):
     """Tests for CFSConfigurationLayer.from_clone_url class method."""
 
-    def setUp(self):
-        self.mock_construct_name = patch.object(CFSConfigurationLayer, 'construct_name').start()
-
-    def tearDown(self):
-        patch.stopall()
-
     def test_from_clone_url(self):
         """Test from_clone_url."""
-        short_name = 'cray'
-        clone_url = f'http://api-gw/vcs/{short_name}-config-management.git'
-        playbook = 'cray.yml'
-        branch = 'main'
-        layer = CFSConfigurationLayer.from_clone_url(clone_url, playbook=playbook, branch=branch)
-
-        self.mock_construct_name.assert_called_once_with(short_name, playbook=playbook,
-                                                         commit=None, branch=branch)
-        self.assertEqual(self.mock_construct_name.return_value, layer.name)
-        self.assertEqual(branch, layer.branch)
-        self.assertEqual(clone_url, layer.clone_url)
-        self.assertIsNone(layer.commit)
+        for cls in (CFSV2ConfigurationLayer, CFSV3ConfigurationLayer):
+            short_name = 'cray'
+            clone_url = f'http://api-gw/vcs/{short_name}-config-management.git'
+            playbook = 'cray.yml'
+            branch = 'main'
+            layer = cls.from_clone_url(clone_url, playbook=playbook, branch=branch)
+            self.assertEqual(branch, layer.branch)
+            self.assertEqual(clone_url, layer.clone_url)
+            self.assertIsNone(layer.commit)
 
     def test_from_clone_url_custom_layer_name(self):
         """Test from_clone_url with custom layer name."""
-        clone_url = f'http://api-gw/vcs/hpe-config-management.git'
-        playbook = 'hpe.yml'
-        branch = 'main'
-        custom_layer_name = 'hpe'
-        layer = CFSConfigurationLayer.from_clone_url(clone_url, name=custom_layer_name,
-                                                     playbook=playbook, branch=branch)
+        for cls in (CFSV2ConfigurationLayer, CFSV3ConfigurationLayer):
+            clone_url = 'http://api-gw/vcs/hpe-config-management.git'
+            playbook = 'hpe.yml'
+            branch = 'main'
+            custom_layer_name = 'hpe'
+            layer = cls.from_clone_url(clone_url, name=custom_layer_name,
+                                       playbook=playbook, branch=branch)
 
-        self.mock_construct_name.assert_not_called()
-        self.assertEqual(custom_layer_name, layer.name)
-        self.assertEqual(branch, layer.branch)
-        self.assertEqual(clone_url, layer.clone_url)
-        self.assertIsNone(layer.commit)
-
-
-class TestCFSConfigurationLayerFromCFS(unittest.TestCase):
-    """Tests for CFSConfigurationLayer.from_cfs class method."""
-
-    def test_from_cfs(self):
-        """Test CFSConfigurationLayer.from_cfs class method."""
-        clone_url = 'https://api-gw-service-nmn.local/vcs/cray/cos-config-management.git'
-        commit = '88cc1c1245882c84f94fd632447986757fe5c045'
-        name = 'cos-integration-2.2.100'
-        playbook = 'ncn.yml'
-        data = {
-            "cloneUrl": clone_url,
-            "commit": commit,
-            "name": name,
-            "playbook": playbook
-        }
-        layer = CFSConfigurationLayer.from_cfs(data)
-        self.assertEqual(clone_url, layer.clone_url)
-        self.assertEqual(commit, layer.commit)
-        self.assertEqual(name, layer.name)
-        self.assertEqual(playbook, layer.playbook)
-        self.assertIsNone(layer.branch)
+            self.assertEqual(custom_layer_name, layer.name)
+            self.assertEqual(branch, layer.branch)
+            self.assertEqual(clone_url, layer.clone_url)
+            self.assertIsNone(layer.commit)
 
 
 class MockFile(io.StringIO):
@@ -485,12 +1110,11 @@ class MockFile(io.StringIO):
         pass
 
 
-class TestCFSConfiguration(unittest.TestCase):
-    """Tests for the CFSConfiguration class."""
+class TestCFSV2Configuration(unittest.TestCase):
+    """Tests for the CFSV2Configuration class."""
     def setUp(self):
         self.mock_cfs_client_cls = patch('csm_api_client.service.cfs.CFSClient').start()
         self.mock_cfs_client = self.mock_cfs_client_cls.return_value
-        self.mock_get_json = self.mock_cfs_client.get.return_value.json
 
         self.example_layer_data = {
             "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/example-config-management.git",
@@ -498,7 +1122,7 @@ class TestCFSConfiguration(unittest.TestCase):
             "name": "example-config",
             "playbook": "example-config.yml"
         }
-        self.example_layer = CFSConfigurationLayer.from_cfs(self.example_layer_data)
+        self.example_layer = CFSV2ConfigurationLayer.from_cfs(self.example_layer_data)
 
         self.new_layer_data = {
             "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/new-config-management.git",
@@ -506,7 +1130,18 @@ class TestCFSConfiguration(unittest.TestCase):
             "name": "new-config",
             "playbook": "new-config.yml"
         }
-        self.new_layer = CFSConfigurationLayer.from_cfs(self.new_layer_data)
+        self.new_layer = CFSV2ConfigurationLayer.from_cfs(self.new_layer_data)
+
+        self.dkms_layer_data = {
+            "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/cos-config-management.git",
+            "commit": "abcdef123456789",
+            "name": "cos-config",
+            "playbook": "cos-config.yml",
+            "specialParameters": {
+                "imsRequireDkms": True
+            }
+        }
+        self.dkms_layer = CFSV2ConfigurationLayer.from_cfs(self.dkms_layer_data)
 
         self.single_layer_config_data = {
             "lastUpdated": "2021-10-20T21:26:04Z",
@@ -515,8 +1150,8 @@ class TestCFSConfiguration(unittest.TestCase):
             ],
             "name": "single-layer-config"
         }
-        self.single_layer_config = CFSConfiguration(self.mock_cfs_client,
-                                                    self.single_layer_config_data)
+        self.single_layer_config = CFSV2Configuration(self.mock_cfs_client,
+                                                      self.single_layer_config_data)
 
         self.duplicate_layer_config_data = {
             "lastUpdated": "2021-10-20T21:26:04Z",
@@ -526,8 +1161,20 @@ class TestCFSConfiguration(unittest.TestCase):
             ],
             "name": "duplicate-layer-config"
         }
-        self.duplicate_layer_config = CFSConfiguration(self.mock_cfs_client,
-                                                       self.duplicate_layer_config_data)
+        self.duplicate_layer_config = CFSV2Configuration(self.mock_cfs_client,
+                                                         self.duplicate_layer_config_data)
+
+        # A configuration with multiple layers
+        self.multiple_layer_config_data = {
+            "lastUpdated": "2021-10-20T21:26:04Z",
+            "layers": [
+                deepcopy(self.example_layer_data),
+                deepcopy(self.dkms_layer_data)
+            ],
+            "name": "multiple-layer-config",
+        }
+        self.multiple_layer_config = CFSV2Configuration(self.mock_cfs_client,
+                                                        self.multiple_layer_config_data)
 
         self.single_layer_file_contents = json.dumps(self.single_layer_config_data)
         self.single_layer_file_obj = MockFile(self.single_layer_file_contents)
@@ -547,51 +1194,98 @@ class TestCFSConfiguration(unittest.TestCase):
     def tearDown(self):
         patch.stopall()
 
-    @patch('csm_api_client.service.cfs.CFSConfigurationLayer.from_cfs')
+    @staticmethod
+    def get_put_configuration_call(config_name, layers):
+        """Return the expected call to put_configuration with the given parameters."""
+        return call(config_name, {'layers': layers}, request_params=None)
+
+    def assert_put_configuration_called(self, config_name, layers):
+        """Assert that put_configuration was called with the given parameters."""
+        self.mock_cfs_client.put_configuration.assert_called_once_with(
+            config_name, {'layers': layers}, request_params=None
+        )
+
+    @patch('csm_api_client.service.cfs.CFSLayerBase.from_cfs')
     def test_construct_cfs_configuration(self, mock_from_cfs):
         """Test the CFSConfiguration constructor."""
-        cfs_config = CFSConfiguration(self.mock_cfs_client, self.single_layer_config_data)
+        cfs_config = CFSV2Configuration(self.mock_cfs_client, self.single_layer_config_data)
         self.assertEqual('single-layer-config', cfs_config.name)
         self.assertEqual([mock_from_cfs.return_value], cfs_config.layers)
+        self.assertIsNone(cfs_config.additional_inventory)
+
+    @patch('csm_api_client.service.cfs.CFSLayerBase.from_cfs')
+    def test_cfs_configuration_preserves_additional_data(self, mock_from_cfs):
+        """Test that CFSConfiguration preserves additional data."""
+        config_data = deepcopy(self.single_layer_config_data)
+        config_data['newProperty'] = 'newValue'
+        config_data['specialParameters'] = {'foo': 'bar'}
+
+        cfs_config = CFSV2Configuration(self.mock_cfs_client, config_data)
+
+        self.assertEqual('single-layer-config', cfs_config.name)
+        self.assertEqual([mock_from_cfs.return_value], cfs_config.layers)
+        self.assertEqual('newValue', cfs_config.passthrough_data['newProperty'])
+        self.assertEqual({'foo': 'bar'}, cfs_config.passthrough_data['specialParameters'])
+
+        req_payload = cfs_config.req_payload
+        self.assertEqual('newValue', req_payload['newProperty'])
+        self.assertEqual({'foo': 'bar'}, req_payload['specialParameters'])
+
+    def test_cfs_configuration_with_additional_inventory(self):
+        """Test that CFSConfiguration can handle additional inventory layer."""
+        config_data = deepcopy(self.single_layer_config_data)
+        config_data['additional_inventory'] = {
+            "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/inventory.git",
+            "commit": "987654321abcdef",
+            "name": "inventory",
+        }
+
+        with patch('csm_api_client.service.cfs.CFSV2AdditionalInventoryLayer.from_cfs') as mock_from_cfs:
+            cfs_config = CFSV2Configuration(self.mock_cfs_client, config_data)
+
+        self.assertEqual('single-layer-config', cfs_config.name)
+        self.assertEqual(1, len(cfs_config.layers))
+        self.assertEqual(mock_from_cfs.return_value, cfs_config.additional_inventory)
 
     def test_construct_empty_configuration(self):
         """Test creating an empty configuration"""
-        self.assertEqual(CFSConfiguration.empty(self.mock_cfs_client).layers, [])
+        self.assertEqual(CFSV2Configuration.empty(self.mock_cfs_client).layers, [])
 
     def test_req_payload(self):
         """Test the req_payload method of CFSConfiguration."""
         self.assertEqual({'layers': [self.example_layer_data]},
                          self.single_layer_config.req_payload)
 
-    def test_save_to_cfs(self):
+    @patch('csm_api_client.service.cfs.CFSLayerBase.from_cfs')
+    def test_save_to_cfs(self, mock_from_cfs):
         """Test that save_to_cfs properly calls the CFS API."""
         config_name = self.single_layer_config_data['name']
         layers = self.single_layer_config_data['layers']
+        self.mock_cfs_client.put_configuration.return_value = self.single_layer_config_data
 
-        with patch('csm_api_client.service.cfs.CFSConfiguration') as mock_cfs_config_cls:
-            updated_config = self.single_layer_config.save_to_cfs()
+        saved_config = self.single_layer_config.save_to_cfs()
 
-        self.mock_cfs_client.put.assert_called_once_with(
-            'configurations', config_name, json={'layers': layers}
-        )
-        mock_cfs_config_cls.assert_called_once_with(
-            self.mock_cfs_client, self.mock_cfs_client.put.return_value.json.return_value)
-        self.assertEqual(mock_cfs_config_cls.return_value, updated_config)
+        self.assert_put_configuration_called(config_name, layers)
+        self.assertIsInstance(saved_config, CFSV2Configuration)
+        self.assertEqual(saved_config.name, config_name)
+        self.assertEqual([mock_from_cfs.return_value], saved_config.layers)
 
-    def test_save_to_cfs_new_name(self):
+    @patch('csm_api_client.service.cfs.CFSLayerBase.from_cfs')
+    def test_save_to_cfs_new_name(self, mock_from_cfs):
         """Test that save_to_cfs saves to a new name."""
         new_name = 'new-config-name'
         layers = self.single_layer_config_data['layers']
 
-        with patch('csm_api_client.service.cfs.CFSConfiguration') as mock_cfs_config_cls:
-            updated_config = self.single_layer_config.save_to_cfs(new_name)
+        expected_saved_config_data = deepcopy(self.single_layer_config_data)
+        expected_saved_config_data['name'] = new_name
+        self.mock_cfs_client.put_configuration.return_value = expected_saved_config_data
 
-        self.mock_cfs_client.put.assert_called_once_with(
-            'configurations', new_name, json={'layers': layers}
-        )
-        mock_cfs_config_cls.assert_called_once_with(
-            self.mock_cfs_client, self.mock_cfs_client.put.return_value.json.return_value)
-        self.assertEqual(mock_cfs_config_cls.return_value, updated_config)
+        saved_config = self.single_layer_config.save_to_cfs(new_name)
+
+        self.assert_put_configuration_called(new_name, layers)
+        self.assertIsInstance(saved_config, CFSV2Configuration)
+        self.assertEqual(saved_config.name, new_name)
+        self.assertEqual([mock_from_cfs.return_value], saved_config.layers)
 
     def test_save_to_cfs_no_overwrite(self):
         """Test preventing overwriting an existing CFS configuration"""
@@ -602,68 +1296,61 @@ class TestCFSConfiguration(unittest.TestCase):
 
     def test_save_to_cfs_api_failure(self):
         """Test that save_to_cfs raises an exception if CFS API request fails."""
-        self.mock_cfs_client.put.side_effect = APIError('cfs problem')
+        api_err_msg = 'cfs problem'
+        self.mock_cfs_client.put_configuration.side_effect = APIError(api_err_msg)
 
-        err_regex = f'Failed to update CFS configuration "single-layer-config": cfs problem'
-
-        with self.assertRaisesRegex(CFSConfigurationError, err_regex):
+        with self.assertRaisesRegex(CFSConfigurationError, api_err_msg):
             self.single_layer_config.save_to_cfs()
 
-    def test_save_to_cfs_bad_json_response(self):
-        """Test that save_to_cfs raises an exception if the response from CFS contains bad JSON."""
-        self.mock_cfs_client.put.return_value.json.side_effect = ValueError('bad json')
-
-        err_regex = (f'Failed to decode JSON response from updating CFS configuration '
-                     f'"single-layer-config": bad json')
-
-        with self.assertRaisesRegex(CFSConfigurationError, err_regex):
-            self.single_layer_config.save_to_cfs()
-
-    def test_save_to_cfs_backup_when_existing(self):
+    @patch('csm_api_client.service.cfs.CFSLayerBase.from_cfs')
+    def test_save_to_cfs_backup_when_existing(self, mock_from_cfs):
         """Test save_to_cfs creates a backup when the configuration already exists."""
-        self.mock_cfs_client.get.return_value.status_code = 200
+        # Mock get to return an existing configuration; use deepcopy because it gets modified with pop
+        self.mock_cfs_client.get.return_value.ok = True
+        self.mock_cfs_client.get.return_value.json.return_value = deepcopy(self.single_layer_config_data)
+
         config_name = self.single_layer_config_data['name']
         layers = self.single_layer_config_data['layers']
         backup_suffix = '.backup'
+        expected_backup_config_data = deepcopy(self.single_layer_config_data)
+        expected_backup_config_data['name'] = f'{config_name}{backup_suffix}'
 
-        # Set up some Mock config objects as CFSConfiguration return values
-        # The first one is the backup copy of the CFSConfiguration
-        backup_config = Mock()
-        # The second one is the new configuration after it's saved to CFS
-        new_config = Mock()
-        mock_cfs_configs = [backup_config, new_config]
+        # Mock put_configuration to return the backup configuration and then the updated configuration
+        self.mock_cfs_client.put_configuration.side_effect = [
+            expected_backup_config_data,
+            self.single_layer_config_data
+        ]
 
-        with patch('csm_api_client.service.cfs.CFSConfiguration') as mock_cfs_config_cls:
-            mock_cfs_config_cls.side_effect = mock_cfs_configs
-            updated_config = self.single_layer_config.save_to_cfs(config_name, backup_suffix=backup_suffix)
+        saved_config = self.single_layer_config.save_to_cfs(config_name, backup_suffix=backup_suffix)
 
-        self.mock_cfs_client.put.assert_called_once_with(
-            'configurations', config_name, json={'layers': layers}
-        )
-
-        mock_cfs_config_cls.assert_has_calls([
-            call(self.mock_cfs_client, self.mock_cfs_client.get.return_value.json.return_value),
-            call(self.mock_cfs_client, self.mock_cfs_client.put.return_value.json.return_value)
+        # The first call to put should be to save the backup copy with no additional request parameters
+        # The next call is to save the requested configuration with the additional request parameters
+        self.mock_cfs_client.put_configuration.assert_has_calls([
+            call(f'{config_name}{backup_suffix}', {'layers': layers}),
+            self.get_put_configuration_call(config_name, layers)
         ])
-        backup_config.save_to_cfs.assert_called_once_with(name=f'{config_name}{backup_suffix}')
-        self.assertEqual(new_config, updated_config)
 
-    def test_save_to_cfs_backup_when_not_existing(self):
-        """Test save_to_cfs creates a backup when the configuration does not exist"""
+        self.assertIsInstance(saved_config, CFSV2Configuration)
+        self.assertEqual(saved_config.name, config_name)
+        self.assertEqual([mock_from_cfs.return_value], saved_config.layers)
+
+    @patch('csm_api_client.service.cfs.CFSLayerBase.from_cfs')
+    def test_save_to_cfs_backup_when_not_existing(self, mock_from_cfs):
+        """Test save_to_cfs does not create a backup when the configuration does not exist"""
         self.mock_cfs_client.get.return_value.ok = False
         self.mock_cfs_client.get.return_value.status_code = 404
         layers = self.single_layer_config_data['layers']
         new_name = 'some-new-name'
+        expected_saved_config_data = deepcopy(self.single_layer_config_data)
+        expected_saved_config_data['name'] = new_name
+        self.mock_cfs_client.put_configuration.return_value = expected_saved_config_data
 
-        with patch('csm_api_client.service.cfs.CFSConfiguration') as mock_cfs_config_cls:
-            saved_config = self.single_layer_config.save_to_cfs(new_name, backup_suffix='.backup')
+        saved_config = self.single_layer_config.save_to_cfs(new_name, backup_suffix='.backup')
 
-        self.mock_cfs_client.put.assert_called_once_with(
-            'configurations', new_name, json={'layers': layers}
-        )
-        mock_cfs_config_cls.assert_called_once_with(
-            self.mock_cfs_client, self.mock_cfs_client.put.return_value.json.return_value)
-        self.assertEqual(mock_cfs_config_cls.return_value, saved_config)
+        self.assert_put_configuration_called(new_name, layers)
+        self.assertIsInstance(saved_config, CFSV2Configuration)
+        self.assertEqual(saved_config.name, new_name)
+        self.assertEqual([mock_from_cfs.return_value], saved_config.layers)
 
     def test_save_to_file(self):
         """Test that saving configuration to a file works"""
@@ -687,12 +1374,50 @@ class TestCFSConfiguration(unittest.TestCase):
         self.assertEqual(2, len(self.single_layer_config.layers))
         self.assertEqual(self.new_layer, self.single_layer_config.layers[1])
 
+    def test_add_new_layer_complicated_config(self):
+        """"Test adding a new layer to a more complicated CFSConfiguration"""
+        self.multiple_layer_config.ensure_layer(self.new_layer, state=LayerState.PRESENT)
+
+        self.assertEqual(3, len(self.multiple_layer_config.layers))
+        self.assertEqual(self.new_layer, self.multiple_layer_config.layers[2])
+
+    def test_update_layer_with_dkms_property(self):
+        """Test updating a layer with the imsRequireDkms special parameter."""
+        dkms_config = CFSV2Configuration(
+            self.mock_cfs_client,
+            {
+                'name': 'dkms-layer-config',
+                'layers': [self.dkms_layer_data],
+                'lastUpdated': '2021-10-20T21:26:04Z'
+            }
+        )
+        new_commit_hash = 'fedcba987654321'
+        updated_layer_data = deepcopy(self.dkms_layer_data)
+        updated_layer_data['commit'] = new_commit_hash
+        updated_layer = CFSV2ConfigurationLayer.from_cfs(updated_layer_data)
+        dkms_config.ensure_layer(updated_layer, state=LayerState.PRESENT)
+
+        self.assertEqual([updated_layer], dkms_config.layers)
+
+    def test_add_new_layer_when_dkms_differs(self):
+        """Test adding a new layer when the imsRequireDkms property differs."""
+        non_dkms_layer_data = deepcopy(self.dkms_layer_data)
+        del non_dkms_layer_data['specialParameters']
+        non_dkms_layer = CFSV2ConfigurationLayer.from_cfs(non_dkms_layer_data)
+
+        # Since this layer now differs in that it does not require dkms, it should be added
+        # instead of modifying the similar layer
+        self.multiple_layer_config.ensure_layer(non_dkms_layer, state=LayerState.PRESENT)
+
+        self.assertEqual(3, len(self.multiple_layer_config.layers))
+        self.assertEqual(non_dkms_layer, self.multiple_layer_config.layers[2])
+
     def test_update_existing_layer(self):
         """Test updating an existing layer in a CFSConfiguration"""
         new_commit_hash = 'fedcba987654321'
         updated_layer_data = deepcopy(self.example_layer_data)
         updated_layer_data['commit'] = new_commit_hash
-        updated_layer = CFSConfigurationLayer.from_cfs(updated_layer_data)
+        updated_layer = CFSV2ConfigurationLayer.from_cfs(updated_layer_data)
 
         self.single_layer_config.ensure_layer(updated_layer, state=LayerState.PRESENT)
 
@@ -703,7 +1428,7 @@ class TestCFSConfiguration(unittest.TestCase):
         new_commit_hash = 'fedcba987654321'
         updated_layer_data = deepcopy(self.example_layer_data)
         updated_layer_data['commit'] = new_commit_hash
-        updated_layer = CFSConfigurationLayer.from_cfs(updated_layer_data)
+        updated_layer = CFSV2ConfigurationLayer.from_cfs(updated_layer_data)
 
         self.duplicate_layer_config.ensure_layer(updated_layer, state=LayerState.PRESENT)
 
@@ -711,7 +1436,7 @@ class TestCFSConfiguration(unittest.TestCase):
 
     def test_update_layer_no_changes(self):
         """Test updating a layer of the CFSConfiguration when nothing has changed."""
-        same_layer = CFSConfigurationLayer.from_cfs(deepcopy(self.example_layer_data))
+        same_layer = CFSV2ConfigurationLayer.from_cfs(deepcopy(self.example_layer_data))
 
         self.single_layer_config.ensure_layer(same_layer, state=LayerState.PRESENT)
 
@@ -720,7 +1445,7 @@ class TestCFSConfiguration(unittest.TestCase):
 
     def test_remove_existing_layer(self):
         """Test removing a matching layer from a CFSConfiguration."""
-        same_layer = CFSConfigurationLayer.from_cfs(deepcopy(self.example_layer_data))
+        same_layer = CFSV2ConfigurationLayer.from_cfs(deepcopy(self.example_layer_data))
 
         self.single_layer_config.ensure_layer(same_layer, state=LayerState.ABSENT)
 
@@ -728,7 +1453,7 @@ class TestCFSConfiguration(unittest.TestCase):
 
     def test_remove_existing_layers(self):
         """Test removing multiple matching layers from a CFSConfiguration."""
-        same_layer = CFSConfigurationLayer.from_cfs(deepcopy(self.example_layer_data))
+        same_layer = CFSV2ConfigurationLayer.from_cfs(deepcopy(self.example_layer_data))
 
         self.duplicate_layer_config.ensure_layer(same_layer, state=LayerState.ABSENT)
 
@@ -742,6 +1467,92 @@ class TestCFSConfiguration(unittest.TestCase):
 
         self.assertEqual(layers_before, self.single_layer_config.layers)
         self.assertFalse(self.single_layer_config.changed)
+
+
+class TestCFSV3Configuration(unittest.TestCase):
+    """Tests for the CFSV3Configuration class.
+
+    Note that the implementation of CFSV3Configuration is identical to CFSV2Configuration, so
+    tests here can be minimal just to ensure that the class is correctly defined.
+    """
+
+    def setUp(self):
+        self.mock_cfs_client_cls = patch('csm_api_client.service.cfs.CFSV3Client').start()
+        self.mock_cfs_client = self.mock_cfs_client_cls.return_value
+        self.mock_get_json = self.mock_cfs_client.get.return_value.json
+
+        self.example_layer_data = {
+            "clone_url": "https://api-gw-service-nmn.local/vcs/cray/example-config-management.git",
+            "commit": "123456789abcdef",
+            "name": "example-config",
+            "playbook": "example-config.yml"
+        }
+
+        self.dkms_layer_data = {
+            "clone_url": "https://api-gw-service-nmn.local/vcs/cray/cos-config-management.git",
+            "commit": "abcdef123456789",
+            "name": "cos-config",
+            "playbook": "cos-config.yml",
+            "special_parameters": {
+                "ims_require_dkms": True
+            }
+        }
+
+        additional_inventory_data = {
+            "clone_url": "https://api-gw-service-nmn.local/vcs/cray/inventory.git",
+            "commit": "987654321abcdef",
+            "name": "inventory",
+        }
+
+        # A configuration with multiple layers
+        self.multiple_layer_config_data = {
+            "last_updated": "2021-10-20T21:26:04Z",
+            "layers": [
+                deepcopy(self.example_layer_data),
+                deepcopy(self.dkms_layer_data)
+            ],
+            "additional_inventory": additional_inventory_data,
+            "name": "multiple-layer-config",
+        }
+        self.multiple_layer_config = CFSV3Configuration(self.mock_cfs_client,
+                                                        self.multiple_layer_config_data)
+
+    def tearDown(self):
+        patch.stopall()
+
+    @staticmethod
+    def get_put_configuration_call(config_name, layers):
+        """Return the expected call to put_configuration with the given parameters."""
+        return call(config_name, {'layers': layers}, request_params=None)
+
+    def assert_put_configuration_called(self, config_name, layers):
+        """Assert that put_configuration was called with the given parameters."""
+        self.mock_cfs_client.put_configuration.assert_called_once_with(
+            config_name, {'layers': layers}, request_params=None
+        )
+
+    @patch('csm_api_client.service.cfs.CFSV3ConfigurationLayer.from_cfs')
+    @patch('csm_api_client.service.cfs.CFSV3AdditionalInventoryLayer.from_cfs')
+    def test_complete_configuration(self, mock_inv_layer, mock_config_layer):
+        """Test creating a CFSV3Configuration with layers and additional_inventory"""
+        config_data = deepcopy(self.multiple_layer_config_data)
+        # Add some additional properties to ensure they're preserved
+        config_data['new_property'] = 'new_value'
+        config_data['special_parameters'] = {'foo': 'bar'}
+
+        cfs_config = CFSV3Configuration(self.mock_cfs_client, config_data)
+
+        self.assertEqual('multiple-layer-config', cfs_config.name)
+        self.assertEqual([mock_config_layer.return_value] * 2, cfs_config.layers)
+        self.assertEqual(mock_inv_layer.return_value, cfs_config.additional_inventory)
+        self.assertEqual('new_value', cfs_config.passthrough_data['new_property'])
+        self.assertEqual({'foo': 'bar'}, cfs_config.passthrough_data['special_parameters'])
+
+        req_payload = cfs_config.req_payload
+        self.assertEqual('new_value', req_payload['new_property'])
+        self.assertEqual({'foo': 'bar'}, req_payload['special_parameters'])
+        self.assertEqual([mock_config_layer.return_value.req_payload] * 2, req_payload['layers'])
+        self.assertEqual(mock_inv_layer.return_value.req_payload, req_payload['additional_inventory'])
 
 
 class TestCFSDebugCommand(unittest.TestCase):
@@ -875,11 +1686,11 @@ class TestCFSUpdateContainerStatus(unittest.TestCase):
                               logs_cm.records[0].message)
 
 
-class TestCFSClient(unittest.TestCase):
+class TestCFSV2Client(unittest.TestCase):
     """Tests for the CFSClient class"""
 
     @staticmethod
-    def get_components(component_ids: List[str]) -> List[dict]:
+    def get_fake_components(component_ids: List[str]) -> List[dict]:
         """Get a fake list of components"""
         components = []
         for component_id in component_ids:
@@ -894,13 +1705,26 @@ class TestCFSClient(unittest.TestCase):
             })
         return components
 
+    def test_join_words(self):
+        """Test the join_words static method of CFSV2Client"""
+        words_and_results = (
+            (('desired', 'config'), 'desiredConfig'),
+            (('DESIRED', 'CONFIG'), 'desiredConfig'),
+            (('deSiReD', 'cOnFiG'), 'desiredConfig'),
+            (('one',), 'one'),
+            (('three', 'word', 'name'), 'threeWordName')
+        )
+        for words, expected_result in words_and_results:
+            self.assertEqual(expected_result,
+                             CFSV2Client.join_words(*words))
+
     def test_get_component_ids_using_config(self):
         """Test get_component_ids_using_config"""
         component_ids = ['x3000c0s1b0n0', 'x3000c0s3b0n0', 'x3000c0s5b0n0']
-        components = self.get_components(component_ids)
+        components = self.get_fake_components(component_ids)
         # For the test, it doesn't have to match, but be consistent to avoid confusion
         config_name = components[0]['desiredConfig']
-        cfs_client = CFSClient(Mock())
+        cfs_client = CFSV2Client(Mock())
 
         with patch.object(cfs_client, 'get') as mock_get:
             mock_get.return_value.json.return_value = components
@@ -911,7 +1735,7 @@ class TestCFSClient(unittest.TestCase):
 
     def test_get_component_ids_using_config_failure(self):
         """Test get_component_ids_using_config when the request fails"""
-        cfs_client = CFSClient(Mock())
+        cfs_client = CFSV2Client(Mock())
         err_msg = 'Service unavailable'
         config_name = 'some-config-name'
 
@@ -923,7 +1747,7 @@ class TestCFSClient(unittest.TestCase):
 
     def test_update_component_no_changes(self):
         """Test update_component with no changes requested"""
-        cfs_client = CFSClient(Mock())
+        cfs_client = CFSV2Client(Mock())
         component_id = 'x1000c0s0b0n0'
 
         with patch.object(cfs_client, 'patch') as mock_patch:
@@ -936,7 +1760,7 @@ class TestCFSClient(unittest.TestCase):
 
     def test_update_component_only_desired_config(self):
         """Test update_component with only a desired_config"""
-        cfs_client = CFSClient(Mock())
+        cfs_client = CFSV2Client(Mock())
         component_id = 'x3000c0s1b0n0'
         desired_config = 'my-config'
 
@@ -948,7 +1772,7 @@ class TestCFSClient(unittest.TestCase):
 
     def test_update_component_all_properties(self):
         """Test update_component with all properties updated"""
-        cfs_client = CFSClient(Mock())
+        cfs_client = CFSV2Client(Mock())
         component_id = 'x3000c0s1b0n0'
         desired_config = 'my-config'
 
@@ -965,3 +1789,79 @@ class TestCFSClient(unittest.TestCase):
 
         mock_patch.assert_called_once_with('components', component_id,
                                            json=expected_json_payload)
+
+
+class TestCFSV3Client(unittest.TestCase):
+    """Tests for the CFSV3Client"""
+
+    def test_join_words(self):
+        """Test the join_words static method of CFSV2Client"""
+        words_and_results = (
+            (('desired', 'config'), 'desired_config'),
+            (('DESIRED', 'CONFIG'), 'desired_config'),
+            (('deSiReD', 'cOnFiG'), 'desired_config'),
+            (('one',), 'one'),
+            (('three', 'word', 'name'), 'three_word_name')
+        )
+        for words, expected_result in words_and_results:
+            self.assertEqual(expected_result,
+                             CFSV3Client.join_words(*words))
+
+    def test_get_components_paged(self):
+        """Test get_components method of CFSV3Client with paged results"""
+        cfs_client = CFSV3Client(Mock())
+        components = [
+            {'id': 'x1000c0s0b0n0'},
+            {'id': 'x1000c0s1b0n0'},
+            {'id': 'x1000c0s2b0n0'},
+            {'id': 'x1000c0s3b0n0'},
+            {'id': 'x1000c0s4b0n0'},
+        ]
+
+        base_params = {'desired_config': 'my-config'}
+        with patch.object(cfs_client, 'get') as mock_get:
+            mock_get.return_value.json.side_effect = [
+                {'components': components[:2], 'next': {'limit': 2, 'after_id': 'x1000c0s1b0n0',
+                                                        'desired_config': 'my-config'}},
+                {'components': components[2:4], 'next': {'limit': 2, 'after_id': 'x1000c0s3b0n0',
+                                                         'desired_config': 'my-config'}},
+                {'components': [components[4]], 'next': None}
+            ]
+
+            result = list(cfs_client.get_components(params=base_params))
+
+        self.assertEqual(components, result)
+        mock_get.assert_has_calls([
+            call('components', params=base_params),
+            call().json(),
+            call('components', params={'limit': 2, 'after_id': 'x1000c0s1b0n0',
+                                       'desired_config': 'my-config'}),
+            call().json(),
+            call('components', params={'limit': 2, 'after_id': 'x1000c0s3b0n0',
+                                       'desired_config': 'my-config'}),
+            call().json()
+        ])
+
+    def test_get_components_unpaged(self):
+        """Test get_components method of CFSV3Client when results are not paged"""
+        cfs_client = CFSV3Client(Mock())
+        components = [
+            {'id': 'x1000c0s0b0n0'},
+            {'id': 'x1000c0s1b0n0'},
+            {'id': 'x1000c0s2b0n0'},
+            {'id': 'x1000c0s3b0n0'},
+            {'id': 'x1000c0s4b0n0'},
+        ]
+
+        with patch.object(cfs_client, 'get') as mock_get:
+            mock_get.return_value.json.side_effect = [
+                {'components': components, 'next': None}
+            ]
+
+            result = list(cfs_client.get_components())
+
+        self.assertEqual(components, result)
+        mock_get.assert_has_calls([
+            call('components', params=None),
+            call().json()
+        ])

--- a/tests/service/test_gateway.py
+++ b/tests/service/test_gateway.py
@@ -137,7 +137,7 @@ class TestAPIGatewayClient(unittest.TestCase):
 
         self.mock_session.session.post.assert_called_once_with(
             get_http_url_prefix(self.api_gw_host) + '/'.join(path_components),
-            data=payload, json=None, timeout=60
+            data=payload, json=None, timeout=60, params=None
         )
         self.assertEqual(response, self.mock_session.session.post.return_value)
 
@@ -159,7 +159,20 @@ class TestAPIGatewayClient(unittest.TestCase):
 
         self.mock_session.session.put.assert_called_once_with(
             get_http_url_prefix(self.api_gw_host) + '/'.join(path_components),
-            data=payload, json=None, timeout=60
+            data=payload, json=None, timeout=60, params=None
+        )
+
+    def test_put_with_params(self):
+        """Test put method with additional params."""
+        client = APIGatewayClient(self.mock_session, timeout=60)
+        path_components = ['People']
+        params = {'name': 'ryan'}
+        payload = {}
+        client.put(*path_components, payload=payload, req_param=params)
+
+        self.mock_session.session.put.assert_called_once_with(
+            get_http_url_prefix(self.api_gw_host) + '/'.join(path_components),
+            data=payload, json=None, timeout=60, params=params
         )
 
     def test_put_exception(self):
@@ -180,7 +193,7 @@ class TestAPIGatewayClient(unittest.TestCase):
 
         self.mock_session.session.patch.assert_called_once_with(
             get_http_url_prefix(self.api_gw_host) + '/'.join(path_components),
-            data=payload, json=None, timeout=60
+            data=payload, json=None, timeout=60, params=None
         )
 
     def test_patch_json(self):
@@ -192,7 +205,7 @@ class TestAPIGatewayClient(unittest.TestCase):
 
         self.mock_session.session.patch.assert_called_once_with(
             get_http_url_prefix(self.api_gw_host) + '/'.join(path_components),
-            data=None, json=json_payload, timeout=60
+            data=None, json=json_payload, timeout=60, params=None
         )
 
     def test_patch_exception(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,114 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+import unittest
+
+from csm_api_client.util import pop_val_by_path, strip_suffix
+
+
+class TestPopValByPath(unittest.TestCase):
+    """Tests for the pop_val_by_path function."""
+
+    def test_pop_val_by_path_flat(self):
+        """Test that the function can pop a value by a flat path."""
+        mapping = {
+            'foo': 'bar'
+        }
+        self.assertEqual(pop_val_by_path(mapping, 'foo'), 'bar')
+        self.assertEqual(mapping, {})
+
+    def test_pop_val_by_path_dotted_path(self):
+        """Test that the function can pop a value by dotted path."""
+        mapping = {
+            'foo': {
+                'bar': 'baz'
+            }
+        }
+        self.assertEqual(pop_val_by_path(mapping, 'foo.bar'), 'baz')
+        self.assertEqual(mapping, {'foo': {}})
+
+    def test_pop_val_by_path_dotted_path_remaining(self):
+        """Test that the function can pop a value by a dotted path and leave other keys unchanged."""
+        mapping = {
+            'foo': {
+                'bar': 'baz',
+                'bat': 'qux'
+            }
+        }
+        self.assertEqual(pop_val_by_path(mapping, 'foo.bar'), 'baz')
+        self.assertEqual(mapping, {'foo': {'bat': 'qux'}})
+
+    def test_pop_val_by_path_missing(self):
+        """Test that the function can pop a value by path when path doesn't exist."""
+        mapping = {
+            'foo': {
+                'bar': 'baz'
+            }
+        }
+        self.assertIsNone(pop_val_by_path(mapping, 'foo.bat'))
+        self.assertEqual(mapping, {'foo': {'bar': 'baz'}})
+
+    def test_pop_val_by_path_missing_default(self):
+        """Test that the function can pop a value by path when path doesn't exist and return a default."""
+        mapping = {
+            'foo': {
+                'bar': 'baz'
+            }
+        }
+        self.assertEqual(pop_val_by_path(mapping, 'foo.bat', 'default'), 'default')
+        self.assertEqual(mapping, {'foo': {'bar': 'baz'}})
+
+    def test_pop_val_by_path_empty(self):
+        """Test that the function can pop a value by path when the dict is empty"""
+        mapping = {}
+        self.assertIsNone(pop_val_by_path(mapping, 'foo.bar'))
+        self.assertEqual(mapping, {})
+
+    def test_pop_val_by_path_empty_path(self):
+        """Test that the function raises an error when the path is empty."""
+        mapping = {
+            'foo': {
+                'bar': 'baz'
+            }
+        }
+        with self.assertRaises(ValueError):
+            pop_val_by_path(mapping, '')
+
+
+class TestStripSuffix(unittest.TestCase):
+    """Tests for the strip_suffix function."""
+
+    def test_strip_suffix(self):
+        """Test that the function can strip a suffix from a string."""
+        self.assertEqual(strip_suffix('foo.bar', '.bar'), 'foo')
+        self.assertEqual(strip_suffix('foo.bar', 'bar'), 'foo.')
+        self.assertEqual(strip_suffix('foo.bar', 'baz'), 'foo.bar')
+        self.assertEqual(strip_suffix('foo.bar', ''), 'foo.bar')
+        self.assertEqual(strip_suffix('foo.bar', 'foo.bar'), '')
+        self.assertEqual(strip_suffix('foo.bar', 'oo.bar'), 'f')
+        self.assertEqual(strip_suffix('foo.bar', 'foo.'), 'foo.bar')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary and Scope
* CRAYSAT-1840: Add support for CFS v3 API

  Add support for the CFS v3 API while preserving support for the CFS v2
  API. This is accomplished by making CFS-API-version specific versions of
  several of the classes in the `cfs` module. For backwards compatibility,
  the existing unversioned class names, `CFSConfiguration`.
  `CFSConfigurationLayer`, and `CFSClient` are now aliases for the
  `CFSV2Configuration`, `CFSV2ConfigurationLayer`, and `CFSV2Client`
  classes.

  The `CFSImageConfigurationSession` class is still used for both CFS v2
  and v3 since there were no large changes required, and it could be
  easily generalized to both CFS API versions.

  As much as possible, functionality that is common between CFS v2 and v3
  is implemented in common abstract base classes which are inherited for
  creating the version-specific classes.

  This change also adds support for additional properties of CFS
  configurations and configuration layers that were not recognized and
  were discarded by old versions of this library. This includes:

  * The `additional_inventory` property of a CFS configuration
  * The `special_parameters` (or `specialParameters`) of a CFS
    configuration layer.
  * Any additional data not understood by this library in a CFS
    configuration should now be retained when the configurations are
    loaded in via the library and then saved to CFS.

  Support for handling paging of CFS components is now handled in the
  `CFSV3Client` with a new `get_components` method.

  This should be a fully backwards compatible upgrade of this library
  since the interfaces to these classes have not changed.

* CRAYSAT-1840: Allow passing request parameters for PUT/PATCH/POST

  We were mistakenly treating request parameters as the body of the
  request for POST, PUT, and PATCH HTTP methods when they can also have
  request parameters in addition to a request body.

  The request parameters are needed now in order to pass a
  `drop_branches=True` parameter while also passing in data in the request
  body in a PUT request to CFS /configurations when creating a CFS
  configuration.

  This change should be backwards compatible as far as the public methods
  of the `APIGatewayClient` class are concerned. It does not change the
  behavior of any callers to the `get`, `put`, `patch`, or `post` methods.
  It just ensures that their request body and parameters are passed to
  `_make_req` appropriately.

## Issues and Related PRs

* Resolves CRAYSAT-1840

## Testing

### Tested on:

  * local macbook

### Test description:

Only tested by unit tests so far. Needs to be tested with changes to `sat` or `cfs-config-util` to use the new version.

## Risks and Mitigations

Pretty significant overhaul of CFSClient code, but backwards compatibility should be retained.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
