### PR TITLE
CRAYSAT-1649: add error logging when unable to find token file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2024-11-26
+
+### Fixed
+-  Fixed issue that did not allow for paths containing `~` to be parsed correctly
+
 ## [2.3.1] - 2024-12-02
 
 ### Fixed

--- a/csm_api_client/session.py
+++ b/csm_api_client/session.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,6 @@
 """
 OAuth2 authentication support.
 """
-
 from abc import ABC, abstractmethod
 import base64
 from functools import cached_property
@@ -90,7 +89,7 @@ class UserSession(Session):
             username: the username whose token to use when authenticating
         """
         self.username = username
-        self.token_filename = token_filename
+        self.token_filename = os.path.expanduser(token_filename)
         self.host = host
         self.fetched_token = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "2.3.1"
+version = "2.3.2"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",


### PR DESCRIPTION
## Summary and Scope

add error logging when unable to find token file path and unwrap ~ as home directory

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1649](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1649)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after https://github.com/Cray-HPE/sat/pull/293

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Rocket
  * Drax
  * Local development environment

### Test description:



## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

