### PR TITLE
CRAYSAT-1896: Fix `CFSLayerBase.req_payload` to include False values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2024-12-02
+
+### Fixed
+- Fixed the `req_payload` property of `CFSLayerBase` to include properties in
+  the CFS request payload even when their values are `False`. For example,
+  include the value of `ims_require_dkms` even when it's set to `False`.
+
 ## [2.3.0] - 2024-11-18
 
 ### Added

--- a/csm_api_client/service/cfs.py
+++ b/csm_api_client/service/cfs.py
@@ -277,7 +277,7 @@ class CFSLayerBase(ABC):
         req_payload = {**self.additional_data}
         for cfs_prop, attr in self.CFS_PROPS_TO_ATTRS.items():
             value = getattr(self, attr, None)
-            if value:
+            if value is not None:
                 set_val_by_path(req_payload, cfs_prop, value)
         return req_payload
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "2.3.0"
+version = "2.3.1"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",

--- a/tests/service/test_cfs.py
+++ b/tests/service/test_cfs.py
@@ -609,7 +609,7 @@ class TestCFSV2ConfigurationLayer(unittest.TestCase):
         self.assertEqual(expected_payload, cfs_layer.req_payload)
 
     def test_payload_with_ims_require_dkms(self):
-        """Test req_payload property of CFSV2ConfigurationLayer with ims_require_dkms."""
+        """Test req_payload property of CFSV2ConfigurationLayer with ims_require_dkms set to True."""
         cfs_layer = CFSV2ConfigurationLayer(
             clone_url=self.clone_url, name=self.name,
             commit=self.commit, playbook=self.playbook,
@@ -622,6 +622,25 @@ class TestCFSV2ConfigurationLayer(unittest.TestCase):
             'playbook': self.playbook,
             'specialParameters': {
                 'imsRequireDkms': True,
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
+        }
+        self.assertEqual(expected_payload, cfs_layer.req_payload)
+
+    def test_payload_with_ims_require_dkms_false(self):
+        """Test req_payload property of CFSV2ConfigurationLayer with ims_require_dkms set to False."""
+        cfs_layer = CFSV2ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook,
+            ims_require_dkms=False, additional_data=self.additional_data
+        )
+        expected_payload = {
+            'commit': self.commit,
+            'name': self.name,
+            'cloneUrl': self.clone_url,
+            'playbook': self.playbook,
+            'specialParameters': {
+                'imsRequireDkms': False,
                 'future_cfs_layer_special_parameter': 'special_value'
             }
         }
@@ -767,7 +786,7 @@ class TestCFSV3ConfigurationLayer(unittest.TestCase):
         self.assertEqual(expected_payload, cfs_layer.req_payload)
 
     def test_payload_with_ims_require_dkms(self):
-        """Test req_payload property of CFSV2ConfigurationLayer with ims_require_dkms."""
+        """Test req_payload property of CFSV3ConfigurationLayer with ims_require_dkms set to True"""
         cfs_layer = CFSV3ConfigurationLayer(
             clone_url=self.clone_url, name=self.name,
             commit=self.commit, playbook=self.playbook,
@@ -780,6 +799,25 @@ class TestCFSV3ConfigurationLayer(unittest.TestCase):
             'playbook': self.playbook,
             'special_parameters': {
                 'ims_require_dkms': True,
+                'future_cfs_layer_special_parameter': 'special_value'
+            }
+        }
+        self.assertEqual(expected_payload, cfs_layer.req_payload)
+
+    def test_payload_with_ims_require_dkms_false(self):
+        """Test req_payload property of CFSV3ConfigurationLayer with ims_require_dkms set to False"""
+        cfs_layer = CFSV3ConfigurationLayer(
+            clone_url=self.clone_url, name=self.name,
+            commit=self.commit, playbook=self.playbook,
+            ims_require_dkms=False, additional_data=self.additional_data
+        )
+        expected_payload = {
+            'commit': self.commit,
+            'name': self.name,
+            'clone_url': self.clone_url,
+            'playbook': self.playbook,
+            'special_parameters': {
+                'ims_require_dkms': False,
                 'future_cfs_layer_special_parameter': 'special_value'
             }
         }


### PR DESCRIPTION
## Summary and Scope

Fix the `req_payload` property of the `CFSLayerBase` class to include values even when they are `False` (or Falsey). This ensures that the `ims_require_dkms` parameter is included in the request payload, even when set to `False`.

Add a unit test for this scenario.

## Issues and Related PRs

* Resolves CRAYSAT-1896

## Testing

### Tested on:

  * rocket

### Test description:

Included in a build of `cray-sat` and tested by creating a CFS configuration containing both true and false values for `ims_require_dkms`.

## Risks and Mitigations

This is pretty low-risk. It's just ensuring False values get included in CFS API requests.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable