### PR TITLE
CRAYSAT-1945: Fix traceback error of session checks in CFS v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.2] - 2024-11-26
+## [2.3.3] - 2024-12-17
 
 ### Fixed
--  Fixed issue that did not allow for paths containing `~` to be parsed correctly
+- Fixed the traceback error encountered during session checks in CFS v2
+  when using a smaller page size.
+
+## [2.3.2] - 2024-12-02
+
+### Fixed
+- Fixed issue that did not allow for paths containing `~` to be parsed correctly
 
 ## [2.3.1] - 2024-12-02
 

--- a/csm_api_client/service/cfs.py
+++ b/csm_api_client/service/cfs.py
@@ -1602,7 +1602,7 @@ class CFSV2Client(CFSClientBase):
         try:
             yield from self.get(resource, params=params).json()
         except APIError as err:
-            raise APIError(f'Failed to get CFS {resource}: {err}')
+            LOGGER.warning(f'Failed to get CFS {resource}: {err}')
         except ValueError as err:
             raise APIError(f'Failed to parse JSON in response from CFS when getting '
                            f'{resource}: {err}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "2.3.2"
+version = "2.3.3"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",

--- a/tests/service/test_cfs.py
+++ b/tests/service/test_cfs.py
@@ -1799,8 +1799,11 @@ class TestCFSV2Client(unittest.TestCase):
         config_name = 'some-config-name'
 
         with patch.object(cfs_client, 'get', side_effect=APIError(err_msg)) as mock_get:
-            with self.assertRaisesRegex(APIError, 'Failed to get components '):
+            with self.assertLogs(level=logging.WARNING) as log:
                 cfs_client.get_component_ids_using_config(config_name)
+
+            self.assertIn("Failed to get CFS components:",
+                          log.output[0])
 
         mock_get.assert_called_once_with('components', params={'configName': config_name})
 


### PR DESCRIPTION
## Summary and Scope

_Fixed the traceback error encountered during session checks in CFS v2 when using a smaller page size._

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1945](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1945)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

