### PR TITLE
CRAYSAT-1784: Support for `drop_branches` in CFS v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-(C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -25,10 +25,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3] - 2025-02-07
+
+### Fixed
+- Added support for the `drop_branches` parameter in CFS v3 configurations.
+  This allows CFS to drop branch names from the CFS layers after resolving them to commit hashes when creating or updating configurations.
+
 ## [2.3.2] - 2024-11-26
 
 ### Fixed
--  Fixed issue that did not allow for paths containing `~` to be parsed correctly
+- Fixed issue that did not allow for paths containing `~` to be parsed correctly
 
 ## [2.3.1] - 2024-12-02
 

--- a/csm_api_client/service/cfs.py
+++ b/csm_api_client/service/cfs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -1628,6 +1628,32 @@ class CFSV3Client(CFSClientBase):
     @staticmethod
     def join_words(*words: str) -> str:
         return '_'.join([word.lower() for word in words])
+
+    def put_configuration(self, config_name: str, request_body: Dict,
+                          request_params: Optional[Dict] = None, drop_branches: bool = False) -> Dict:
+        """Create a new configuration or update an existing configuration
+
+        Args:
+            config_name: the name of the configuration to create/update
+            request_body: the configuration data, which should have a
+                'layers' key.
+            request_params: the parameters to pass
+            drop_branches: whether to drop branches and use commit hashes only
+
+        Returns:
+            The details of the newly updated or created session
+        """
+        if request_params is None:
+            request_params = {}
+        request_params['drop_branches'] = drop_branches
+
+        try:
+            return self.put('configurations', config_name, json=request_body, req_param=request_params).json()
+        except APIError as err:
+            raise APIError(f'Failed to update CFS configuration {config_name}: {err}')
+        except ValueError as err:
+            raise APIError(f'Failed to parse JSON in response from CFS when updating '
+                           f'CFS configuration {config_name}: {err}')
 
     def get_paged_resource(self, resource: str, params: Dict = None) -> Generator[Dict, None, None]:
         """Get a paged resource from the CFS API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "csm-api-client"
-version = "2.3.2"
+version = "2.3.3"
 description = "Python client library for CSM APIs"
 authors = [
     "Ryan Haasken <ryan.haasken@hpe.com>",


### PR DESCRIPTION
## Summary and Scope

_Stop resolving branch names to commit hashes from `sat bootprep` in cfs v3. Use `drop_branches` parameter supported by cfs for v3_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1784](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1784)

## Testing

_Will test from sat using unstable build_

## Risks and Mitigations

_Min_

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

